### PR TITLE
First fix for meta head titles

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html lang="en">
   <head>
+    <title>D-sektionen</title>
     <meta charset="utf-8" />
     <link rel="icon" href="%sveltekit.assets%/favicon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />

--- a/src/lib/components/PageHeader.svelte
+++ b/src/lib/components/PageHeader.svelte
@@ -5,6 +5,8 @@
 <svelte:head>
   {#if title}
     <title>{title} | D-sektionen</title>
+  {:else}
+    <title>D-sektionen</title>
   {/if}
 </svelte:head>
 

--- a/src/lib/utils/member.ts
+++ b/src/lib/utils/member.ts
@@ -61,7 +61,7 @@ export const getCustomAuthorOptions = async (memberId: string) => {
   });
 };
 
-export const getFullName = (member: Member) => {
-  if (member?.nickname) return `${member.firstName} "${member.nickname}" ${member.lastName}`;
+export const getFullName = (member: Pick<Member, "nickname" | "firstName" | "lastName">) => {
+  if (member.nickname) return `${member.firstName} "${member.nickname}" ${member.lastName}`;
   return `${member.firstName} ${member.lastName}`;
 };

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -5,13 +5,9 @@
   export let data;
 </script>
 
-<svelte:head>
-  <title>D-sektionen</title>
-</svelte:head>
-
 <NavBar accessPolicies={data.accessPolicies}>
   <div
-    class="accent-primary h-[calc(100vh-9rem)] flex-col overflow-auto pb-8 md:h-[calc(100vh-5rem)] [&>*]:flex-1"
+    class="h-[calc(100vh-9rem)] flex-col overflow-auto pb-8 accent-primary md:h-[calc(100vh-5rem)] [&>*]:flex-1"
   >
     <slot />
   </div>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -2,6 +2,10 @@
   export let data;
 </script>
 
+<svelte:head>
+  <title>D-sektionen</title>
+</svelte:head>
+
 <div class="min-h-screen bg-[url('/hero-image.jpg')] bg-cover bg-center bg-no-repeat">
   <div class="bg-opacity-60"></div>
   <h1>{data.numberOfUniqueVolunteers} unika funkisar</h1>

--- a/src/routes/admin/access/+page.svelte
+++ b/src/routes/admin/access/+page.svelte
@@ -8,6 +8,10 @@
     .sort();
 </script>
 
+<svelte:head>
+  <title>Access policies | D-sektionen</title>
+</svelte:head>
+
 <div class="overflow-x-auto">
   <table class="table">
     <!-- head -->

--- a/src/routes/admin/access/[apiName]/+page.svelte
+++ b/src/routes/admin/access/[apiName]/+page.svelte
@@ -11,6 +11,10 @@
   });
 </script>
 
+<svelte:head>
+  <title>{$page.params.apiName} | D-sektionen</title>
+</svelte:head>
+
 <h1 class="mb-4 text-4xl font-semibold">{$page.params.apiName}</h1>
 <div class="overflow-x-auto">
   <table class="table">

--- a/src/routes/documents/+page.server.ts
+++ b/src/routes/documents/+page.server.ts
@@ -41,16 +41,13 @@ export const load = async ({ parent, url }) => {
       });
       break;
   }
-  const filesGroupedByMeeting = filteredFiles.reduce(
-    (acc, file) => {
-      const fileParts = file.id.split("/");
-      const meeting = fileParts[fileParts.length - 2] ?? "unknown";
-      if (!acc[meeting]) acc[meeting] = [];
-      acc[meeting]!.push(file);
-      return acc;
-    },
-    {} as Record<string, FileData[]>
-  );
+  const filesGroupedByMeeting = filteredFiles.reduce<Record<string, FileData[]>>((acc, file) => {
+    const fileParts = file.id.split("/");
+    const meeting = fileParts[fileParts.length - 2] ?? "unknown";
+    if (!acc[meeting]) acc[meeting] = [];
+    acc[meeting]!.push(file);
+    return acc;
+  }, {});
   return {
     files,
     meetings: filesGroupedByMeeting,

--- a/src/routes/documents/+page.svelte
+++ b/src/routes/documents/+page.svelte
@@ -28,6 +28,10 @@
   );
 </script>
 
+<svelte:head>
+  <title>Dokument | D-sektionen</title>
+</svelte:head>
+
 <div class="flex flex-row justify-between">
   <div class="mb-4 flex flex-col items-start gap-2">
     <a href="/documents/governing">Styrdokument</a>

--- a/src/routes/documents/governing/+page.svelte
+++ b/src/routes/documents/governing/+page.svelte
@@ -5,6 +5,10 @@
   $: guidelines = data.governingDocuments.filter((doc) => doc.documentType === "GUIDELINE");
 </script>
 
+<svelte:head>
+  <title>Styrdokument | D-sektionen</title>
+</svelte:head>
+
 <h1 class="my-3 text-2xl font-bold">Styrdokument</h1>
 <div class="flex flex-col gap-5">
   <p>

--- a/src/routes/documents/upload/+page.svelte
+++ b/src/routes/documents/upload/+page.svelte
@@ -7,6 +7,10 @@
   let files: FileList | undefined = undefined;
 </script>
 
+<svelte:head>
+  <title>Ladda upp dokument | D-sektionen</title>
+</svelte:head>
+
 <form
   id="upload-file"
   class="form-control items-stretch"

--- a/src/routes/events/+page.svelte
+++ b/src/routes/events/+page.svelte
@@ -17,6 +17,10 @@
   $: isPast = $page.url.searchParams.get("past") == "on";
 </script>
 
+<svelte:head>
+  <title>Evenemang | D-sektionen</title>
+</svelte:head>
+
 <section class="flex flex-col gap-2">
   <div class="flex items-center gap-2">
     <a class="btn" href="/events/calendar"

--- a/src/routes/events/[slug]/+page.svelte
+++ b/src/routes/events/[slug]/+page.svelte
@@ -6,6 +6,10 @@
   $: event = data.event;
 </script>
 
+<svelte:head>
+  <title>{event.title} | D-sektionen</title>
+</svelte:head>
+
 <Event {event}>
   <div slot="actions">
     {#if data.canEdit}

--- a/src/routes/events/[slug]/edit/+page@.svelte
+++ b/src/routes/events/[slug]/edit/+page@.svelte
@@ -6,6 +6,10 @@
   export let form;
 </script>
 
+<svelte:head>
+  <title>Redigera evenemang | D-sektionen</title>
+</svelte:head>
+
 <EventEditor {...data} formData={form?.data}>
   <input slot="form-end" type="hidden" value={$page.params.slug} name="slug" />
   <div slot="error">

--- a/src/routes/events/calendar/+page.svelte
+++ b/src/routes/events/calendar/+page.svelte
@@ -4,4 +4,8 @@
   export let data;
 </script>
 
+<svelte:head>
+  <title>Kalender | D-sektionen</title>
+</svelte:head>
+
 <Calendar events={data.events} />

--- a/src/routes/events/create/+page@.svelte
+++ b/src/routes/events/create/+page@.svelte
@@ -6,6 +6,10 @@
   export let form;
 </script>
 
+<svelte:head>
+  <title>Skapa evenemang | D-sektionen</title>
+</svelte:head>
+
 <EventEditor {...data} formData={form?.data}>
   <div slot="error">
     {#if form?.error}

--- a/src/routes/members/[studentId]/+page.svelte
+++ b/src/routes/members/[studentId]/+page.svelte
@@ -15,7 +15,7 @@
   export let form;
   $: member = data.member;
   $: isMe = data.session?.user?.student_id === $page.params.studentId;
-  $: mandatesGroupedByYear = member.mandates.reduce(
+  $: mandatesGroupedByYear = member.mandates.reduce<Record<string, (typeof member)["mandates"]>>(
     (acc, mandate) => {
       let year = mandate.startDate.getFullYear().toString();
       if (mandate.endDate.getFullYear() !== mandate.startDate.getFullYear())
@@ -24,7 +24,7 @@
       acc[year]!.push(mandate);
       return acc;
     },
-    {} as Record<string, (typeof member)["mandates"]>
+    {}
   );
   $: years = Object.keys(mandatesGroupedByYear).sort((a, b) => b.localeCompare(a, "sv"));
   $: publishedEvents = [...member.authoredEvents].reverse();

--- a/src/routes/news/+page.svelte
+++ b/src/routes/news/+page.svelte
@@ -17,6 +17,10 @@
   );
 </script>
 
+<svelte:head>
+  <title>Nyheter | D-sektionen</title>
+</svelte:head>
+
 <section class="flex flex-col gap-2">
   <div class="flex items-center gap-2">
     {#if data.accessPolicies.includes(apiNames.NEWS.CREATE)}

--- a/src/routes/news/[slug]/+page.svelte
+++ b/src/routes/news/[slug]/+page.svelte
@@ -11,6 +11,10 @@
   $: author = article.author;
 </script>
 
+<svelte:head>
+  <title>{article.header} | D-sektionen</title>
+</svelte:head>
+
 <article>
   <Article {article}>
     <AuthorSignature

--- a/src/routes/news/[slug]/edit/+page@.svelte
+++ b/src/routes/news/[slug]/edit/+page@.svelte
@@ -6,6 +6,10 @@
   export let form;
 </script>
 
+<svelte:head>
+  <title>Redigera nyhet | D-sektionen</title>
+</svelte:head>
+
 <ArticleEditor
   selectedTags={data.article.tags}
   selectedAuthorOption={data.article.author}

--- a/src/routes/news/create/+page@.svelte
+++ b/src/routes/news/create/+page@.svelte
@@ -6,6 +6,10 @@
   export let form;
 </script>
 
+<svelte:head>
+  <title>Skapa nyhet | D-sektionen</title>
+</svelte:head>
+
 <ArticleEditor {...data} formData={form?.data}>
   <div slot="error">
     {#if form?.error}

--- a/src/routes/news/tags/+page.svelte
+++ b/src/routes/news/tags/+page.svelte
@@ -8,6 +8,10 @@
   let createLoading = false;
 </script>
 
+<svelte:head>
+  <title>Nyhetstaggar | D-sektionen</title>
+</svelte:head>
+
 <div class="overflow-x-auto">
   <table class="table">
     <!-- head -->

--- a/src/routes/positions/[id]/+page.svelte
+++ b/src/routes/positions/[id]/+page.svelte
@@ -11,22 +11,25 @@
   import AddMandateForm from "./AddMandateForm.svelte";
   export let data;
   export let form;
-  $: groupedByYear = data.mandates.reduce(
-    (acc, mandate) => {
-      let year = mandate.startDate.getFullYear().toString();
-      if (mandate.endDate.getFullYear() !== mandate.startDate.getFullYear())
-        year += `-${mandate.endDate.getFullYear()}`;
-      if (!acc[year]) acc[year] = [];
-      acc[year]!.push(mandate);
-      return acc;
-    },
-    {} as Record<string, Prisma.MandateGetPayload<{ include: { member: true } }>[]>
-  );
+  $: groupedByYear = data.mandates.reduce<
+    Record<string, Prisma.MandateGetPayload<{ include: { member: true } }>[]>
+  >((acc, mandate) => {
+    let year = mandate.startDate.getFullYear().toString();
+    if (mandate.endDate.getFullYear() !== mandate.startDate.getFullYear())
+      year += `-${mandate.endDate.getFullYear()}`;
+    if (!acc[year]) acc[year] = [];
+    acc[year]!.push(mandate);
+    return acc;
+  }, {});
   $: years = Object.keys(groupedByYear).sort((a, b) => b.localeCompare(a, "sv"));
   let isEditing = false;
   let isAdding = false;
   let editedMandate: (typeof data.mandates)[number] | undefined = undefined;
 </script>
+
+<svelte:head>
+  <title>{data.position.name} | D-sektionen</title>
+</svelte:head>
 
 <div class="flex items-center justify-between">
   <PageHeader title={data.position.name} />


### PR DESCRIPTION
First fix for meta head titles, needs to respect preferred language later.

`<svelte:head>` should be put in `+page.svelte` or component files instead on `+layout.svelte` files.

Minor TS changes with types.