### PR TITLE
Make UpdateMemberForm Responsive

### DIFF
--- a/src/lib/components/Labeled.svelte
+++ b/src/lib/components/Labeled.svelte
@@ -6,7 +6,11 @@
   export let fullWidth: boolean = false;
 </script>
 
-<div class={`relative inline-flex flex-col items-stretch ${fullWidth ? 'w-full md:w-auto' : ''}`}>
+<div
+  class={`relative inline-flex flex-col items-stretch ${
+    fullWidth ? "w-full md:w-auto" : ""
+  }`}
+>
   {#if label}
     <label class="label" for={id}>
       <span class="label-text">

--- a/src/lib/components/Labeled.svelte
+++ b/src/lib/components/Labeled.svelte
@@ -3,9 +3,10 @@
   export let label: string | null = null;
   export let explanation: string | null = null;
   export let error: string | string[] | undefined = undefined;
+  export let fullWidth: boolean = false;
 </script>
 
-<div class="relative inline-flex flex-col items-stretch">
+<div class={`relative inline-flex flex-col items-stretch ${fullWidth ? 'w-full md:w-auto' : ''}`}>
   {#if label}
     <label class="label" for={id}>
       <span class="label-text">

--- a/src/routes/members/[studentId]/UpdateMemberForm.svelte
+++ b/src/routes/members/[studentId]/UpdateMemberForm.svelte
@@ -75,7 +75,7 @@
         type="number"
         name="classYear"
         id="classYear"
-        class="w-xs input input-bordered"
+        class="input input-bordered md:max-w-20"
         bind:value={$form.classYear}
         {...$constraints.classYear}
       />

--- a/src/routes/members/[studentId]/UpdateMemberForm.svelte
+++ b/src/routes/members/[studentId]/UpdateMemberForm.svelte
@@ -21,7 +21,7 @@
   method="POST"
   action="?/update"
   use:enhance
-  class="form-control gap-2 p-5 max-w-full"
+  class="form-control max-w-full gap-2 p-5"
 >
   <div class="flex flex-wrap gap-2 [&>*]:flex-1">
     <Input
@@ -46,12 +46,17 @@
       error={$errors.lastName}
     />
   </div>
-  <div class="flex gap-2 flex-wrap [&>*:nth-child(3)]:flex-1 w-full">
-    <Labeled label="Program" id="classProgramme" error={$errors.classProgramme} fullWidth={true} md:max-w-xs>
+  <div class="flex w-full flex-wrap gap-2 [&>*:nth-child(3)]:flex-1">
+    <Labeled
+      label="Program"
+      id="classProgramme"
+      error={$errors.classProgramme}
+      fullWidth={true}
+    >
       <select
         id="classProgramme"
         name="classProgramme"
-        class="select select-bordered w-full md:max-w-xs"
+        class="w-xs select select-bordered w-full"
         bind:value={$form.classProgramme}
         {...$constraints.classProgramme}
       >
@@ -60,12 +65,17 @@
         {/each}
       </select>
     </Labeled>
-    <Labeled label="Year" id="classProgramme" error={$errors.classYear} fullWidth={true} md:max-w-xs>
+    <Labeled
+      label="Year"
+      id="classProgramme"
+      error={$errors.classYear}
+      fullWidth={true}
+    >
       <input
         type="number"
         name="classYear"
         id="classYear"
-        class="input input-bordered"
+        class="w-xs input input-bordered"
         bind:value={$form.classYear}
         {...$constraints.classYear}
       />
@@ -80,3 +90,11 @@
   </div>
   <button type="submit" class="btn btn-secondary mt-4">Spara</button>
 </form>
+
+<style>
+  @media (min-width: 768px) {
+    .w-xs {
+      max-width: 20rem;
+    }
+  }
+</style>

--- a/src/routes/members/[studentId]/UpdateMemberForm.svelte
+++ b/src/routes/members/[studentId]/UpdateMemberForm.svelte
@@ -21,7 +21,7 @@
   method="POST"
   action="?/update"
   use:enhance
-  class="form-control max-w-full gap-2 p-5"
+  class="form-control max-w-full gap-2"
 >
   <div class="flex flex-wrap gap-2 [&>*]:flex-1">
     <Input

--- a/src/routes/members/[studentId]/UpdateMemberForm.svelte
+++ b/src/routes/members/[studentId]/UpdateMemberForm.svelte
@@ -21,9 +21,9 @@
   method="POST"
   action="?/update"
   use:enhance
-  class="form-control gap-2"
+  class="form-control gap-2 p-5 max-w-full"
 >
-  <div class="flex gap-2 [&>*]:flex-1">
+  <div class="flex flex-wrap gap-2 [&>*]:flex-1">
     <Input
       name="firstName"
       label="First name"
@@ -46,12 +46,12 @@
       error={$errors.lastName}
     />
   </div>
-  <div class="flex gap-2 [&>*:nth-child(3)]:flex-1">
-    <Labeled label="Program" id="classProgramme" error={$errors.classProgramme}>
+  <div class="flex gap-2 flex-wrap [&>*:nth-child(3)]:flex-1 w-full">
+    <Labeled label="Program" id="classProgramme" error={$errors.classProgramme} fullWidth={true} md:max-w-xs>
       <select
         id="classProgramme"
         name="classProgramme"
-        class="select select-bordered w-full max-w-xs"
+        class="select select-bordered w-full md:max-w-xs"
         bind:value={$form.classProgramme}
         {...$constraints.classProgramme}
       >
@@ -60,7 +60,7 @@
         {/each}
       </select>
     </Labeled>
-    <Labeled label="Year" id="classProgramme" error={$errors.classYear}>
+    <Labeled label="Year" id="classProgramme" error={$errors.classYear} fullWidth={true} md:max-w-xs>
       <input
         type="number"
         name="classYear"

--- a/src/routes/members/[studentId]/UpdateMemberForm.svelte
+++ b/src/routes/members/[studentId]/UpdateMemberForm.svelte
@@ -51,7 +51,7 @@
       label="Program"
       id="classProgramme"
       error={$errors.classProgramme}
-      fullWidth={true}
+      fullWidth
     >
       <select
         id="classProgramme"

--- a/src/routes/members/[studentId]/UpdateMemberForm.svelte
+++ b/src/routes/members/[studentId]/UpdateMemberForm.svelte
@@ -56,7 +56,7 @@
       <select
         id="classProgramme"
         name="classProgramme"
-        class="w-xs select select-bordered w-full"
+        class="select select-bordered w-full md:max-w-20"
         bind:value={$form.classProgramme}
         {...$constraints.classProgramme}
       >

--- a/src/routes/members/[studentId]/UpdateMemberForm.svelte
+++ b/src/routes/members/[studentId]/UpdateMemberForm.svelte
@@ -91,10 +91,3 @@
   <button type="submit" class="btn btn-secondary mt-4">Spara</button>
 </form>
 
-<style>
-  @media (min-width: 768px) {
-    .w-xs {
-      max-width: 20rem;
-    }
-  }
-</style>

--- a/src/routes/members/[studentId]/UpdateMemberForm.svelte
+++ b/src/routes/members/[studentId]/UpdateMemberForm.svelte
@@ -69,7 +69,7 @@
       label="Year"
       id="classProgramme"
       error={$errors.classYear}
-      fullWidth={true}
+      fullWidth
     >
       <input
         type="number"

--- a/src/routes/members/[studentId]/UpdateMemberForm.svelte
+++ b/src/routes/members/[studentId]/UpdateMemberForm.svelte
@@ -90,4 +90,3 @@
   </div>
   <button type="submit" class="btn btn-secondary mt-4">Spara</button>
 </form>
-


### PR DESCRIPTION
# Closes issue #155 

## Description

This pull request addresses the offscreen form issue on small screens when editing user information on the profile page. Additionally, it enhances the `Labeled` component to support full-width rendering based on the `fullWidth` prop.

### Changes Made

#### Form Component Changes:
- Added `max-w-full` and increased padding (`p-5`) to the form container for better responsiveness.
- Adjusted the flex properties for better wrapping and responsiveness on both form sections.
- Modified the width of the select input and text input to be responsive and controlled by media queries.
- Added a new style block with a media query to set a maximum width for the `.w-xs` class on screens larger than 768px.

#### Labeled Component Changes:
- Added a new prop `fullWidth` to the `Labeled` component, defaulting to `false`.
- Conditionally applied the `w-full` and `md:w-auto` classes based on the value of the `fullWidth` prop, allowing the component to adapt to different layout requirements.

## Screenshots

<img width="1436" alt="lg" src="https://github.com/Dsek-LTH/web/assets/108215785/ed1df977-5486-4b03-82f6-e1b2a137c69d">
<img width="1436" alt="md" src="https://github.com/Dsek-LTH/web/assets/108215785/444d7a2a-8564-4a81-983a-1f43101a4602">
<img width="1433" alt="sm" src="https://github.com/Dsek-LTH/web/assets/108215785/e07951f1-b5fa-4eb2-a115-32fb5a5a8425">


## Checklist

- [x] Tested the changes on different screen sizes.
- [x] No new linting errors or warnings.