### PR TITLE
Add verbose door names

### DIFF
--- a/src/database/prisma/migrations/20240306193950_add_verbose_door_name/migration.sql
+++ b/src/database/prisma/migrations/20240306193950_add_verbose_door_name/migration.sql
@@ -1,0 +1,18 @@
+-- Add column
+ALTER TABLE "doors" ADD COLUMN "verbose_name" VARCHAR(255);
+
+-- Set values for existing values
+UPDATE "doors" SET verbose_name = 'Border (caféförrådet)'     WHERE "name" = 'border';
+UPDATE "doors" SET verbose_name = 'Fulförrådet'               WHERE "name" = 'ful';
+UPDATE "doors" SET verbose_name = 'Buren'                     WHERE "name" = 'buren';
+UPDATE "doors" SET verbose_name = 'iDét'                      WHERE "name" = 'idet';
+UPDATE "doors" SET verbose_name = 'Köket'                     WHERE "name" = 'koket';
+UPDATE "doors" SET verbose_name = 'Komitea'                   WHERE "name" = 'komitea';
+UPDATE "doors" SET verbose_name = 'Mauer (caféförrådet)'      WHERE "name" = 'mauer';
+UPDATE "doors" SET verbose_name = 'Sexförrådet'               WHERE "name" = 'sex';
+UPDATE "doors" SET verbose_name = 'Städförrådet'              WHERE "name" = 'stad';
+UPDATE "doors" SET verbose_name = 'Råsenbad (styrelserummet)' WHERE "name" = 'styrelserummet';
+UPDATE "doors" SET verbose_name = 'Utskott'                   WHERE "name" = 'utskott';
+
+-- Impose not null constraint
+ALTER TABLE "doors" ALTER COLUMN "verbose_name" SET NOT NULL;

--- a/src/database/prisma/schema.prisma
+++ b/src/database/prisma/schema.prisma
@@ -304,11 +304,12 @@ model DoorAccessPolicy {
 /// @@allow('create', has(auth().policies, 'core:access:door:create'))
 /// @@allow('read', has(auth().policies, 'core:access:door:read'))
 /// @@allow('delete', has(auth().policies, 'core:access:door:delete'))
-/// This model or at least one of its fields has comments in the database, and requires an additional setup for migrations: Read more: https://pris.ly/d/database-commentsmodel Doors{
+/// This model or at least one of its fields has comments in the database, and requires an additional setup for migrations: Read more: https://pris.ly/d/database-comments
 model Door {
     name String @id() @db.VarChar(255)
     id String? @db.VarChar(255)
     accessPolicies DoorAccessPolicy[]
+    verboseName String @map("verbose_name") @db.VarChar(255)
 
     @@map("doors")
 }

--- a/src/database/schema.zmodel
+++ b/src/database/schema.zmodel
@@ -288,11 +288,12 @@ model DoorAccessPolicy {
   @@map("door_access_policies")
 }
 
-/// This model or at least one of its fields has comments in the database, and requires an additional setup for migrations: Read more: https://pris.ly/d/database-commentsmodel Doors{
+/// This model or at least one of its fields has comments in the database, and requires an additional setup for migrations: Read more: https://pris.ly/d/database-comments
 model Door {
   name String @id @db.VarChar(255)
   id String? @db.VarChar(255)
   accessPolicies DoorAccessPolicy[]
+  verboseName String @map("verbose_name") @db.VarChar(255)
 
   @@allow("create", has(auth().policies, "core:access:door:create"))
   @@allow("read", has(auth().policies, "core:access:door:read"))

--- a/src/routes/(app)/admin/doors/+page.svelte
+++ b/src/routes/(app)/admin/doors/+page.svelte
@@ -15,11 +15,12 @@
     <tbody>
       {#each data.doors as door (door.name)}
         <tr>
-          <td class="font-medium capitalize">{door.name}</td>
-          <td class="text-right"
-            ><a class="btn btn-xs px-8" href="doors/edit/{door.name}">Edit</a
-            ></td
-          >
+          <td class="font-medium">
+            {door.verboseName}
+          </td>
+          <td class="text-right">
+            <a class="btn btn-xs px-8" href="doors/edit/{door.name}">Edit</a>
+          </td>
         </tr>
       {/each}
     </tbody>


### PR DESCRIPTION
This PR adds a verbose name field to doors to make it easier for people to understand which door access policies and the like refer to.