### PR TITLE
Ensure filled board positions are not shown as vacant

### DIFF
--- a/src/routes/(app)/board/+page.svelte
+++ b/src/routes/(app)/board/+page.svelte
@@ -8,72 +8,81 @@
 
 <PageHeader title="Styrelsen" />
 <!-- TODO: make this editable by board members with Markdown page -->
-<p>
-  Styrelsen ansvarar för den dagliga verksamheten på sektionen. Till styrelsen
-  kan du alltid vända dig om du har frågor, funderingar eller åsikter om
-  sektionen och dess verksamhet. Styrelsen sammanträder på styrelsemöten varje
-  vecka och är öppna för alla medlemmar.
-</p>
-<br />
-<p>
-  Styrelsen kan nås på <a class="text-primary" href="mailto:styrelsen@dsek.se"
-    >styrelsen@dsek.se</a
-  >
-</p>
-<br />
-<div
-  class="grid grid-cols-1 items-stretch justify-items-stretch gap-4 sm:grid-cols-2 md:grid-cols-3"
->
-  {#each data.boardPositions as member (member.position.id)}
-    <div class="card bg-base-200 transition-all">
-      {#if member.studentId && member.firstName && member.nickname && member.lastName}
-        <a
-          href="/members/{member.studentId}"
-          class="group card bg-base-200 shadow-xl transition-all hover:bg-base-200/80"
-        >
-          <figure class="mt-4 transition-transform group-hover:scale-90">
-            <MemberAvatar {member} class="h-24 w-24 rounded-full" />
-          </figure>
-          <div class="card-body px-0 text-center">
-            <h2 class="card-title mx-auto">
-              {getFullName(member)}
+<section class="mb-5 space-y-5">
+  <p>
+    Styrelsen ansvarar för den dagliga verksamheten på sektionen. Till styrelsen
+    kan du alltid vända dig om du har frågor, funderingar eller åsikter om
+    sektionen och dess verksamhet. Styrelsen sammanträder på styrelsemöten varje
+    vecka som är öppna för alla medlemmar.
+  </p>
+  <p>
+    Styrelsen kan nås på <a
+      class="text-primary"
+      href="mailto:styrelsen@dsek.se"
+    >
+      styrelsen@dsek.se
+    </a>
+  </p>
+</section>
+
+<section class="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3">
+  {#each data.boardPositions as boardMember (boardMember.position.id)}
+    <div class="card bg-base-200 shadow-xl">
+      {#if boardMember.studentId && boardMember.firstName && boardMember.nickname && boardMember.lastName}
+        <div class="group/photo card-body p-4 text-center">
+          <a href="/members/{boardMember.studentId}" class="group/link">
+            <figure class="transition-transform group-hover/photo:scale-90">
+              <MemberAvatar member={boardMember} class="size-24 rounded-full" />
+            </figure>
+            <h2
+              class="card-title mt-8 block text-pretty text-primary group-hover/link:underline"
+            >
+              {getFullName(boardMember)}
             </h2>
-            <div class="flex flex-col gap-1 px-2 text-base-content/90">
-              <a
-                class="text-xl hover:underline"
-                href="/positions/{member.position.id}">{member.position.name}</a
-              >
-              <a
-                class="text-sm hover:underline"
-                href="mailto:{member.position.email}"
-              >
-                <span class="i-mdi-email m-1 h-max text-base-content"
-                  >{member.position.email}</span
-                >{member.position.email}</a
-              >
-            </div>
+          </a>
+          <div class="flex flex-col gap-1 px-2 text-base-content/90">
+            <a
+              class="hover:underline"
+              href="/positions/{boardMember.position.id}"
+            >
+              {boardMember.position.name}
+            </a>
+            <a
+              class="flex items-center justify-center gap-1 text-sm text-base-content/50 hover:underline"
+              href="mailto:{boardMember.position.email}"
+            >
+              <span class="i-mdi-email" />
+              {boardMember.position.email}
+            </a>
           </div>
-        </a>
+        </div>
       {:else}
         <!-- position is vacant -->
-        <div
-          class="group card bg-base-200 shadow-xl transition-all hover:bg-base-200/80"
-        >
-          <figure class="mt-4 transition-transform group-hover:scale-90">
+        <div class="group/photo">
+          <figure class="mt-4 transition-transform group-hover/photo:scale-90">
             <!-- MemberAvatar renders well even with null-values -->
-            <MemberAvatar {member} class="h-24 w-24 rounded-full" />
+            <MemberAvatar member={boardMember} class="size-24 rounded-full" />
           </figure>
           <div class="card-body px-0 text-center">
-            <h2 class="card-title mx-auto">V.A. Kant</h2>
+            <h2 class="card-title mx-auto text-primary">V.A. Kant</h2>
             <div class="flex flex-col gap-1 px-2 text-base-content/90">
               <a
-                class="text-xl hover:underline"
-                href="/positions/{member.position.id}">{member.position.name}</a
+                class="hover:underline"
+                href="/positions/{boardMember.position.id}"
               >
+                {boardMember.position.name}
+              </a>
+              <a
+                class="flex items-center justify-center gap-1 text-sm text-base-content/50 hover:underline"
+                href="mailto:{boardMember.position.email}"
+              >
+                <span class="i-mdi-email" />
+                {boardMember.position.email}
+              </a>
             </div>
           </div>
         </div>
       {/if}
     </div>
   {/each}
-</div>
+</section>

--- a/src/routes/(app)/board/+page.svelte
+++ b/src/routes/(app)/board/+page.svelte
@@ -28,7 +28,7 @@
 <section class="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3">
   {#each data.boardPositions as boardMember (boardMember.position.id)}
     <div class="card bg-base-200 shadow-xl">
-      {#if boardMember.studentId && boardMember.firstName && boardMember.nickname && boardMember.lastName}
+      {#if boardMember.studentId}
         <div class="group/photo card-body p-4 text-center">
           <a href="/members/{boardMember.studentId}" class="group/link">
             <figure class="transition-transform group-hover/photo:scale-90">


### PR DESCRIPTION
As can be seen in the "Before" image below, there was a bug where board member positions would be shown as vacant, even though they weren't. It was easily fixed by changing the if-statement that determines if the position is vacant. Aside from fixing the bug, I also tweaked the design of the page.

Before:
![dsek vercel app_board](https://github.com/Dsek-LTH/web/assets/26229521/9e24e621-e05b-42a0-8345-f27efb4cc8c7)

After:
![web-git-205-board-positions-are-vacant-dsek vercel app_board](https://github.com/Dsek-LTH/web/assets/26229521/374abf11-24ea-4902-8d5f-b63d2c705914)
