### PR TITLE
Fix bug causing toasts to appear behind icons

### DIFF
--- a/src/routes/Toast.svelte
+++ b/src/routes/Toast.svelte
@@ -16,7 +16,7 @@
 </script>
 
 {#if $toasts}
-  <div class="toast bottom-2 right-2">
+  <div class="toast bottom-2 right-2 z-10">
     {#each $toasts as toast (toast.id)}
       <div
         role="alert"


### PR DESCRIPTION
This pull request fixes a bug that was causing toasts to appear behind icons. This PR simply adds z-index property to ensure that the toasts are displayed on top of other elements.