### PR TITLE
Move two navbar buttons to drawer on mobile

### DIFF
--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -1,11 +1,18 @@
 <script lang="ts">
   import GlobalAlert from "$lib/components/GlobalAlert.svelte";
   import { languageTag } from "$paraglide/runtime";
+  import { onMount } from "svelte";
+  import { themeChange } from "theme-change";
   import "../../app.css";
   import Drawer from "../Drawer.svelte";
   import Footer from "../Footer.svelte";
   import Navbar from "../Navbar.svelte";
   import Toast from "../Toast.svelte";
+
+  onMount(() => {
+    themeChange(false);
+    // 👆 false parameter is required for svelte
+  });
 
   export let data;
 </script>

--- a/src/routes/DarkLightToggle.svelte
+++ b/src/routes/DarkLightToggle.svelte
@@ -1,14 +1,11 @@
 <script lang="ts">
-  import { onMount } from "svelte";
-  import { themeChange } from "theme-change";
+  import { twMerge } from "tailwind-merge";
 
-  onMount(() => {
-    themeChange(false);
-    // 👆 false parameter is required for svelte
-  });
+  let clazz = "";
+  export { clazz as class };
 </script>
 
-<label class="btn btn-ghost swap swap-rotate *:text-2xl">
+<label class={twMerge("btn btn-ghost swap swap-rotate *:text-2xl", clazz)}>
   <!-- this hidden checkbox controls the state -->
   <input type="checkbox" data-toggle-theme="dark,light" />
 

--- a/src/routes/Drawer.svelte
+++ b/src/routes/Drawer.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   import { page } from "$app/stores";
   import { isAuthorized } from "$lib/utils/authorization";
+  import { i18n } from "$lib/utils/i18n";
+  import { languageTag } from "$paraglide/runtime";
   import DsekLogo from "./DsekLogo.svelte";
   import { routes } from "./routes";
 
@@ -12,53 +14,85 @@
 
 <input id="main-drawer" type="checkbox" class="drawer-toggle" bind:checked />
 <div class="drawer-side z-20">
-  <label for="main-drawer" aria-label="close sidebar" class="drawer-overlay"
-  ></label>
-  <ul class="menu min-h-full min-w-60 bg-base-200 pr-6 font-semibold">
-    {#each routes as route (route.title)}
-      {#if !route.accessRequired || isAuthorized(route.accessRequired, $page.data.user)}
-        {#if route?.children?.length}
-          <li class="py-1">
-            <details open>
-              <summary class="active:!bg-primary/10">
+  <label for="main-drawer" aria-label="close sidebar" class="drawer-overlay" />
+
+  <ul class="menu min-h-full min-w-60 bg-base-200 p-0 font-semibold">
+    <div class="navbar justify-between p-2 pl-6 pr-4 shadow-md">
+      <div class="flex gap-2">
+        <DsekLogo className="size-6 text-primary" />
+        <p class="font-thin">D-SEKTIONEN</p>
+      </div>
+      <div class="flex *:px-1">
+        <label class="btn btn-ghost swap swap-rotate btn-sm rounded *:text-xl">
+          <!-- this hidden checkbox controls the state -->
+          <input type="checkbox" data-toggle-theme="dark,light" />
+
+          <!-- moon icon -->
+          <span class="swap-on i-mdi-weather-night" />
+
+          <!-- sun icon -->
+          <span class="swap-off i-mdi-weather-sunny" />
+        </label>
+        <div class="btn btn-ghost btn-sm rounded">
+          {#if languageTag() === "sv"}
+            <a href={i18n.route($page.url.pathname)} hreflang="en">EN</a>
+          {:else if languageTag() === "en"}
+            <a href={i18n.route($page.url.pathname)} hreflang="sv">SV</a>
+          {/if}
+        </div>
+      </div>
+    </div>
+
+    <div class="p-2 pr-6">
+      {#each routes as route (route.title)}
+        {#if !route.accessRequired || isAuthorized(route.accessRequired, $page.data.user)}
+          {#if route?.children?.length}
+            <li class="py-1">
+              <details>
+                <summary class="active:!bg-primary/10">
+                  {#if route.isDsekIcon}
+                    <DsekLogo className="size-6 text-primary" />
+                  {:else}
+                    <span class={`${route.icon} size-6 text-primary`} />
+                  {/if}
+                  {route.title}
+                </summary>
+                <ul>
+                  {#each route.children as child (child.title)}
+                    {#if !child.accessRequired || isAuthorized(child.accessRequired, $page.data.user)}
+                      <li class="py-1">
+                        <a
+                          on:click={close}
+                          href={child.path}
+                          class="active:!bg-primary/10"
+                        >
+                          <span class={`${child.icon} size-6 text-primary`} />
+                          {child.title}
+                        </a>
+                      </li>
+                    {/if}
+                  {/each}
+                </ul>
+              </details>
+            </li>
+          {:else}
+            <li class="py-1">
+              <a
+                on:click={close}
+                href={route.path}
+                class="active:!bg-primary/10"
+              >
                 {#if route.isDsekIcon}
-                  <DsekLogo className="h-6 w-6 text-primary" />
+                  <DsekLogo className="size-6 text-primary" />
                 {:else}
-                  <span class={`${route.icon} h-6 w-6 text-primary`} />
+                  <span class={`${route.icon} size-6 text-primary`} />
                 {/if}
                 {route.title}
-              </summary>
-              <ul>
-                {#each route.children as child (child.title)}
-                  {#if !child.accessRequired || isAuthorized(child.accessRequired, $page.data.user)}
-                    <li class="py-1">
-                      <a
-                        on:click={close}
-                        href={child.path}
-                        class="active:!bg-primary/10"
-                      >
-                        <span class={`${child.icon} h-6 w-6 text-primary`} />
-                        {child.title}
-                      </a>
-                    </li>
-                  {/if}
-                {/each}
-              </ul>
-            </details>
-          </li>
-        {:else}
-          <li class="py-1">
-            <a on:click={close} href={route.path} class="active:!bg-primary/10">
-              {#if route.isDsekIcon}
-                <DsekLogo className="h-6 w-6 text-primary" />
-              {:else}
-                <span class={`${route.icon} h-6 w-6 text-primary`} />
-              {/if}
-              {route.title}
-            </a>
-          </li>
+              </a>
+            </li>
+          {/if}
         {/if}
-      {/if}
-    {/each}
+      {/each}
+    </div>
   </ul>
 </div>

--- a/src/routes/Drawer.svelte
+++ b/src/routes/Drawer.svelte
@@ -17,30 +17,21 @@
   <label for="main-drawer" aria-label="close sidebar" class="drawer-overlay" />
 
   <ul class="menu min-h-full min-w-60 bg-base-200 p-0 font-semibold">
-    <div class="navbar justify-between p-2 pl-6 pr-4 shadow-md">
-      <div class="flex gap-2">
-        <DsekLogo className="size-6 text-primary" />
-        <p class="font-thin">D-SEKTIONEN</p>
-      </div>
-      <div class="flex *:px-1">
-        <label class="btn btn-ghost swap swap-rotate btn-sm rounded *:text-xl">
-          <!-- this hidden checkbox controls the state -->
-          <input type="checkbox" data-toggle-theme="dark,light" />
-
-          <!-- moon icon -->
-          <span class="swap-on i-mdi-weather-night" />
-
-          <!-- sun icon -->
-          <span class="swap-off i-mdi-weather-sunny" />
-        </label>
-        <div class="btn btn-ghost btn-sm rounded">
-          {#if languageTag() === "sv"}
-            <a href={i18n.route($page.url.pathname)} hreflang="en">EN</a>
-          {:else if languageTag() === "en"}
-            <a href={i18n.route($page.url.pathname)} hreflang="sv">SV</a>
-          {/if}
-        </div>
-      </div>
+    <div class="flex gap-2 p-2 pb-0">
+      <label class="btn btn-ghost swap swap-rotate flex-1 bg-base-300">
+        <input type="checkbox" data-toggle-theme="dark,light" />
+        <span class="swap-on i-mdi-weather-night size-6" />
+        <span class="swap-off i-mdi-weather-sunny size-6" />
+      </label>
+      {#if languageTag() === "sv" || languageTag() === "en"}
+        <a
+          class="btn btn-ghost flex-1 bg-base-300"
+          href={i18n.route($page.url.pathname)}
+          hreflang={languageTag() === "sv" ? "en" : "sv"}
+        >
+          <span class="i-mdi-translate size-6" />
+        </a>
+      {/if}
     </div>
 
     <div class="p-2 pr-6">

--- a/src/routes/Drawer.svelte
+++ b/src/routes/Drawer.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
   import { page } from "$app/stores";
   import { isAuthorized } from "$lib/utils/authorization";
-  import { i18n } from "$lib/utils/i18n";
-  import { languageTag } from "$paraglide/runtime";
+  import DarkLightToggle from "./DarkLightToggle.svelte";
   import DsekLogo from "./DsekLogo.svelte";
+  import LanguageSwitcher from "./LanguageSwitcher.svelte";
   import { routes } from "./routes";
 
   let checked = false;
@@ -18,20 +18,10 @@
 
   <ul class="menu min-h-full min-w-60 bg-base-200 p-0 font-semibold">
     <div class="flex gap-2 p-2 pb-0">
-      <label class="btn btn-ghost swap swap-rotate flex-1 bg-base-300">
-        <input type="checkbox" data-toggle-theme="dark,light" />
-        <span class="swap-on i-mdi-weather-night size-6" />
-        <span class="swap-off i-mdi-weather-sunny size-6" />
-      </label>
-      {#if languageTag() === "sv" || languageTag() === "en"}
-        <a
-          class="btn btn-ghost flex-1 bg-base-300"
-          href={i18n.route($page.url.pathname)}
-          hreflang={languageTag() === "sv" ? "en" : "sv"}
-        >
-          <span class="i-mdi-translate size-6" />
-        </a>
-      {/if}
+      <DarkLightToggle class="flex-1 bg-base-300 *:size-6" />
+      <LanguageSwitcher class="flex-1 bg-base-300">
+        <span class="i-mdi-translate size-6" />
+      </LanguageSwitcher>
     </div>
 
     <div class="p-2 pr-6">

--- a/src/routes/LanguageSwitcher.svelte
+++ b/src/routes/LanguageSwitcher.svelte
@@ -3,24 +3,19 @@
   import { page } from "$app/stores";
   import { i18n } from "$lib/utils/i18n";
   import { invalidateAll } from "$app/navigation";
+  import { twMerge } from "tailwind-merge";
+
+  let clazz = "";
+  export { clazz as class };
 </script>
 
-{#if languageTag() === "sv"}
-  <a
-    href={i18n.route($page.url.pathname)}
-    class="btn btn-ghost"
-    hreflang="en"
-    on:click={() => invalidateAll()}
-  >
-    EN
-  </a>
-{:else if languageTag() === "en"}
-  <a
-    href={i18n.route($page.url.pathname)}
-    class="btn btn-ghost"
-    hreflang="sv"
-    on:click={() => invalidateAll()}
-  >
-    SV
-  </a>
-{/if}
+<a
+  class={twMerge("btn btn-ghost", clazz)}
+  href={i18n.route($page.url.pathname)}
+  hreflang={languageTag() === "sv" ? "en" : "sv"}
+  on:click={() => invalidateAll()}
+>
+  <slot>
+    {languageTag() === "sv" ? "EN" : "SV"}
+  </slot>
+</a>

--- a/src/routes/Navbar.svelte
+++ b/src/routes/Navbar.svelte
@@ -34,9 +34,9 @@
             <!-- svelte-ignore a11y-label-has-associated-control -->
             <label tabindex="0" class="btn btn-ghost">
               {#if route.isDsekIcon}
-                <DsekLogo className="h-6 w-6 text-primary" />
+                <DsekLogo className="size-6 text-primary" />
               {:else}
-                <span class={`${route.icon} h-6 w-6 text-primary`} />
+                <span class={`${route.icon} size-6 text-primary`} />
               {/if}
               {route.title}</label
             >
@@ -52,7 +52,7 @@
                       href={child.path}
                       class="btn-ghost active:!bg-primary/10"
                     >
-                      <span class={`${child.icon} h-6 w-6 text-primary`} />
+                      <span class={`${child.icon} size-6 text-primary`} />
                       {child.title}</a
                     >
                   </li>
@@ -63,9 +63,9 @@
         {:else}
           <a class="btn btn-ghost" href={route.path}>
             {#if route.isDsekIcon}
-              <DsekLogo className="h-6 w-6 text-primary" />
+              <DsekLogo className="size-6 text-primary" />
             {:else}
-              <span class={`${route.icon} h-6 w-6 text-primary`} />
+              <span class={`${route.icon} size-6 text-primary`} />
             {/if}
             {route.title}
           </a>
@@ -75,8 +75,12 @@
   </div>
 
   <div class="flex">
-    <LanguageSwitcher />
-    <DarkLightToggle />
+    <div class="hidden lg:flex">
+      <!-- This will be shown in the drawer instead. -->
+      <DarkLightToggle />
+      <LanguageSwitcher />
+    </div>
+
     {#if $page.data.user && $page.data.member}
       <Notification />
       <div class="dropdown dropdown-end dropdown-hover">
@@ -103,11 +107,11 @@
                 href={`/members/${$page.data.user?.studentId}`}
                 class="btn btn-ghost w-48 justify-start text-base-content"
               >
-                <span class="i-mdi-account-circle h-6 w-6 text-primary" />
+                <span class="i-mdi-account-circle size-6 text-primary" />
                 Profil
               </a>
               <a href="/settings" class="btn btn-ghost w-48 justify-start">
-                <span class="i-mdi-cog h-6 w-6 text-primary" />
+                <span class="i-mdi-cog size-6 text-primary" />
                 Inställningar
               </a>
             </div>
@@ -116,7 +120,7 @@
               class="btn btn-ghost justify-start"
               on:click={() => signOut()}
             >
-              <span class="i-mdi-logout h-6 w-6 text-primary" />
+              <span class="i-mdi-logout size-6 text-primary" />
               Logga ut</button
             >
           </div>


### PR DESCRIPTION
This PR moves two navbar buttons to the drawer on mobile devices to improve the user experience and make better use of the available screen space. Also makes some other changes to the navbar design and some tailwind class name simplifications.

Before (iPhone SE):
![dsek vercel app_(iPhone SE)](https://github.com/Dsek-LTH/web/assets/26229521/1fffc20e-1d2c-448c-914f-0eea0187bcf5)

After (iPhone SE):
![localhost_5173_en(iPhone SE)](https://github.com/Dsek-LTH/web/assets/26229521/3d870058-11c5-4c88-b883-74c9b335c148)
