### PR TITLE
Add "person responsible" field to booking admin table

### DIFF
--- a/src/database/prisma/migrations/20240420113050_add_booking_relation_to_member/migration.sql
+++ b/src/database/prisma/migrations/20240420113050_add_booking_relation_to_member/migration.sql
@@ -1,0 +1,2 @@
+-- AddForeignKey
+ALTER TABLE "booking_requests" ADD CONSTRAINT "booking_requests_booker_id_foreign" FOREIGN KEY ("booker_id") REFERENCES "members"("id") ON DELETE NO ACTION ON UPDATE NO ACTION;

--- a/src/database/prisma/schema.prisma
+++ b/src/database/prisma/schema.prisma
@@ -218,6 +218,7 @@ model BookingRequest {
     event String? @db.VarChar(255)
     status BookingRequestStatus @default(PENDING)
     bookables Bookable[] @relation("booking_requests_bookables")
+    booker Member? @relation(fields: [bookerId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "booking_requests_booker_id_foreign")
 
     @@map("booking_requests")
 }
@@ -524,6 +525,7 @@ model Member {
     authoredShoppables Shoppable[]
     inventory Consumable[]
     shopReservations ConsumableReservation[]
+    bookingRequests BookingRequest[]
 
     @@map("members")
 }

--- a/src/database/schema.zmodel
+++ b/src/database/schema.zmodel
@@ -191,6 +191,7 @@ model BookingRequest {
   event String? @db.VarChar(255)
   status BookingRequestStatus @default(PENDING)
   bookables Bookable[] @relation("booking_requests_bookables")
+  booker Member? @relation(fields: [bookerId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "booking_requests_booker_id_foreign")
 
   @@allow("create", has(auth().policies, "booking_request:create"))
   @@allow("read", has(auth().policies, "booking_request:read"))
@@ -501,6 +502,7 @@ model Member {
   authoredShoppables Shoppable[]
   inventory Consumable[]
   shopReservations ConsumableReservation[]
+  bookingRequests BookingRequest[]
 
   @@allow('create', has(auth().policies, "core:member:create"))
   @@allow('create', auth().studentId == studentId)

--- a/src/database/schema.zmodel
+++ b/src/database/schema.zmodel
@@ -365,7 +365,7 @@ model Event {
   interested Member[] @relation("event_interested")
   author Member @relation(fields: [authorId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "events_author_id_foreign")
   tags Tag[] @relation("event_tags")
-	tickets Ticket[]
+  tickets Ticket[]
 
   @@allow("create", has(auth().policies, "event:create"))
   @@allow("read", has(auth().policies, "event:read"))
@@ -373,7 +373,6 @@ model Event {
   @@allow("update", has(auth().policies, "event:update"))
   @@allow("delete", has(auth().policies, "event:delete"))
   @@map("events")
-
 }
 
 /// This model or at least one of its fields has comments in the database, and requires an additional setup for migrations: Read more: https://pris.ly/d/database-comments
@@ -499,9 +498,9 @@ model Member {
   subscriptionSettings SubscriptionSetting[]
   memberSpecificPolicies AccessPolicy[]
   doorAccessPolicies DoorAccessPolicy[]
-	authoredShoppables Shoppable[]
-	inventory Consumable[]
-	shopReservations ConsumableReservation[]
+  authoredShoppables Shoppable[]
+  inventory Consumable[]
+  shopReservations ConsumableReservation[]
 
   @@allow('create', has(auth().policies, "core:member:create"))
   @@allow('create', auth().studentId == studentId)
@@ -841,9 +840,9 @@ model Shoppable {
   removedAt DateTime? @map("removed_at") @db.Timestamptz(6)
 
   ticket Ticket?
-	consumables Consumable[]
-	reservations ConsumableReservation[]
-	questions ItemQuestion[]
+  consumables Consumable[]
+  reservations ConsumableReservation[]
+  questions ItemQuestion[]
 
   // create: acces and mark self as author
   @@allow("create", has(auth().policies, "webshop:create") && authorId == auth().memberId)
@@ -888,8 +887,8 @@ model ItemQuestion {
   descriptionEn String?
   type String @db.VarChar(255) // like "choice", "free-text" etc
   forExternalsOnly Boolean @default(false) // if question should only be shown for people without an account
-	options ItemQuestionOption[]
-	responses ItemQuestionResponse[]
+  options ItemQuestionOption[]
+  responses ItemQuestionResponse[]
 
   // create: author of shoppable
   @@allow("create", shoppable.authorId == auth().memberId)
@@ -907,7 +906,7 @@ model ItemQuestionOption {
   id String @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
   questionId String @db.Uuid
   question ItemQuestion @relation(fields: [questionId], references: [id], onDelete: Cascade, onUpdate: NoAction)
-  
+
   answer String
   answerEn String?
   extraPrice Int?
@@ -954,7 +953,7 @@ model Consumable {
   shoppableId String @db.Uuid
   shoppable Shoppable @relation(fields: [shoppableId], references: [id], onDelete: NoAction, onUpdate: NoAction)
 
-  memberId String? @db.Uuid 
+  memberId String? @db.Uuid
   member Member? @relation(fields: [memberId], references: [id])
   externalCustomerEmail String? // if purchased by a non-member
   externalCustomerCode String? // if purchased by a non-member, unique code used in link as security
@@ -965,10 +964,10 @@ model Consumable {
   stripeIntentId String? @map("stripe_intent_id")
 
   // customer or webshop:consume can always consume from unconsumed state. manager can "unconsume" from consumed state
-  consumedAt DateTime? @map("consumed_at") @db.Timestamptz(6) @allow("update",  (has(auth().policies, "webshop:consume") && consumedAt == null) 
+  consumedAt DateTime? @map("consumed_at") @db.Timestamptz(6) @allow("update", (has(auth().policies, "webshop:consume") && consumedAt == null) 
                                                                                 || has(auth().policies, "webshop:manage"), true)
 
-	questionResponses ItemQuestionResponse[]
+  questionResponses ItemQuestionResponse[]
 
   // create: anyone, but only for themselves
   @@allow("create", memberId == auth().memberId || auth().externalCode != null && externalCustomerCode == auth().externalCode)
@@ -990,7 +989,7 @@ model ConsumableReservation {
   shoppableId String @db.Uuid
   shoppable Shoppable @relation(fields: [shoppableId], references: [id], onDelete: NoAction, onUpdate: NoAction)
 
-  memberId String? @db.Uuid 
+  memberId String? @db.Uuid
   member Member? @relation(fields: [memberId], references: [id])
   externalCustomerEmail String? // if purchased by a non-member
   externalCustomerCode String? // if purchased by a non-member, unique code used in link as security
@@ -1007,5 +1006,4 @@ model ConsumableReservation {
   // customer can delete
   @@allow("delete", (memberId == auth().memberId || auth().externalCode != null && externalCustomerCode == auth().externalCode))
   @@map("consumable_reservation")
-
 }

--- a/src/routes/(app)/booking/admin/+page.server.ts
+++ b/src/routes/(app)/booking/admin/+page.server.ts
@@ -15,6 +15,7 @@ export const load: PageServerLoad = async ({ locals }) => {
     orderBy: [{ start: "asc" }, { end: "asc" }, { status: "asc" }],
     include: {
       bookables: true,
+      booker: true,
     },
   });
 

--- a/src/routes/(app)/booking/admin/+page.svelte
+++ b/src/routes/(app)/booking/admin/+page.svelte
@@ -2,6 +2,8 @@
   import dayjs from "dayjs";
   import StatusComponent from "./StatusComponent.svelte";
   import { enhance } from "$app/forms";
+  import { getFullName } from "$lib/utils/client/member";
+  import MemberAvatar from "$lib/components/socials/MemberAvatar.svelte";
   export let data;
 </script>
 
@@ -18,6 +20,7 @@
         <th>Från</th>
         <th>Till</th>
         <th>Evenemang</th>
+        <th>Ansvarig</th>
         <th>Status</th>
         <th />
       </tr>
@@ -34,6 +37,21 @@
           <td>{dayjs(bookingRequest.start).format("YYYY-MM-DD HH:MM")}</td>
           <td>{dayjs(bookingRequest.end).format("YYYY-MM-DD HH:MM")}</td>
           <td>{bookingRequest.event}</td>
+          <td>
+            <div class="flex items-center gap-2">
+              {#if bookingRequest.booker}
+                <MemberAvatar
+                  member={bookingRequest.booker}
+                  class="size-5 flex-shrink-0"
+                />
+                <a
+                  href="/members/{bookingRequest.booker.studentId}"
+                  class="link-hover link"
+                  >{getFullName(bookingRequest.booker)}
+                </a>
+              {/if}
+            </div>
+          </td>
           <td>
             <StatusComponent
               bind:bookingRequest

--- a/src/routes/(app)/booking/admin/+page.svelte
+++ b/src/routes/(app)/booking/admin/+page.svelte
@@ -39,17 +39,15 @@
           <td>{bookingRequest.event}</td>
           <td>
             <div class="flex items-center gap-2">
-              {#if bookingRequest.booker}
-                <MemberAvatar
-                  member={bookingRequest.booker}
-                  class="size-5 flex-shrink-0"
-                />
-                <a
-                  href="/members/{bookingRequest.booker.studentId}"
-                  class="link-hover link"
-                  >{getFullName(bookingRequest.booker)}
-                </a>
-              {/if}
+              <MemberAvatar
+                member={bookingRequest.booker}
+                class="size-5 flex-shrink-0"
+              />
+              <a
+                href="/members/{bookingRequest.booker.studentId}"
+                class="link-hover link"
+                >{getFullName(bookingRequest.booker)}
+              </a>
             </div>
           </td>
           <td>


### PR DESCRIPTION
This pull request adds a new column to the booking admin table that displays the person responsible for each booking request. The person responsible is fetched from the database and displayed in the table alongside other booking details.