### PR TITLE
Use plain markdownToTxt for article excerpts

### DIFF
--- a/src/routes/(app)/news/SmallArticleCard.svelte
+++ b/src/routes/(app)/news/SmallArticleCard.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
   import DOMPurify from "isomorphic-dompurify";
-  import { marked } from "marked";
   import { getFullName } from "$lib/utils/client/member";
   import type { Article } from "./articles";
   import MemberAvatar from "$lib/components/socials/MemberAvatar.svelte";
   import dayjs from "dayjs";
   import { goto } from "$app/navigation";
+  import markdownToTxt from "markdown-to-txt";
   export let article: Article;
 </script>
 
@@ -30,8 +30,7 @@
           {article.header}
         </h1>
         <div class="prose mb-8 mt-2 line-clamp-3 prose-headings:text-sm">
-          <!-- eslint-disable-next-line svelte/no-at-html-tags -- Sanitized client-side -->
-          {@html marked(DOMPurify.sanitize(article.body))}
+          {markdownToTxt(DOMPurify.sanitize(article.body))}
         </div>
       </button>
     </div>


### PR DESCRIPTION
This PR replaces the use of the "marked" library with the "markdownToTxt" library for generating plain text excerpts of articles. See result below:

Before:
![image](https://github.com/Dsek-LTH/web/assets/26229521/b64d80e4-3589-44db-8867-7aac8b272b33)

After:
![image](https://github.com/Dsek-LTH/web/assets/26229521/1535f673-3be0-487f-bbdd-8cfea7bf261b)

Note that the text says `image` multiple times because that's the images' [alt tags](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img) ([source](https://www.markdownguide.org/basic-syntax/#images-1)). I would argue that's user error and not something this PR should fix.