### PR TITLE
Refresh data on language switch

### DIFF
--- a/src/routes/LanguageSwitcher.svelte
+++ b/src/routes/LanguageSwitcher.svelte
@@ -2,14 +2,25 @@
   import { languageTag } from "$paraglide/runtime";
   import { page } from "$app/stores";
   import { i18n } from "$lib/utils/i18n";
+  import { invalidateAll } from "$app/navigation";
 </script>
 
 {#if languageTag() === "sv"}
-  <a href={i18n.route($page.url.pathname)} class="btn btn-ghost" hreflang="en">
+  <a
+    href={i18n.route($page.url.pathname)}
+    class="btn btn-ghost"
+    hreflang="en"
+    on:click={() => invalidateAll()}
+  >
     EN
   </a>
 {:else if languageTag() === "en"}
-  <a href={i18n.route($page.url.pathname)} class="btn btn-ghost" hreflang="sv">
+  <a
+    href={i18n.route($page.url.pathname)}
+    class="btn btn-ghost"
+    hreflang="sv"
+    on:click={() => invalidateAll()}
+  >
     SV
   </a>
 {/if}


### PR DESCRIPTION
Before you had to refresh the page manually after switching language to get the translated content.

I found two ways to fix this: 
[`data-sveltekit-reload`](https://kit.svelte.dev/docs/link-options#data-sveltekit-reload) which reloads the whole page.
[`invalidateAll()`](https://kit.svelte.dev/docs/modules#$app-navigation-invalidateall) which I went for, causes load functions to re-run.
