### PR TITLE
Add automatically generated API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,4 @@ vite.config.ts.timestamp-*
 /.vercel
 .zenstack_repl_history
 project.inlang/project_id
-src/database/openapi.yaml
+src/routes/api/openapi.json/openapi.json

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ vite.config.ts.timestamp-*
 /.vercel
 .zenstack_repl_history
 project.inlang/project_id
+src/database/openapi.yaml

--- a/.prettierignore
+++ b/.prettierignore
@@ -8,7 +8,7 @@ node_modules
 !.env.example
 /.vscode
 src/translations/paraglide
-
+src/database/openapi.yaml
 # Ignore files for PNPM, NPM and YARN
 pnpm-lock.yaml
 package-lock.json

--- a/.prettierignore
+++ b/.prettierignore
@@ -8,7 +8,7 @@ node_modules
 !.env.example
 /.vscode
 src/translations/paraglide
-src/database/openapi.yaml
+src/routes/api/openapi.json/openapi.json
 # Ignore files for PNPM, NPM and YARN
 pnpm-lock.yaml
 package-lock.json

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "vite-node": "^1.1.0",
     "vitest": "^1.2.2",
     "vitest-mock-extended": "^1.3.1",
-    "zenstack": "^1.7.1",
+    "zenstack": "^1.11.1",
     "zod": "^3.22.4"
   },
   "type": "module",
@@ -88,7 +88,8 @@
     "@tiptap/pm": "^2.1.13",
     "@tiptap/starter-kit": "^2.1.13",
     "@vercel/speed-insights": "^1.0.10",
-    "@zenstackhq/runtime": "^1.7.1",
+    "@zenstackhq/runtime": "^1.11.1",
+    "@zenstackhq/server": "^1.11.1",
     "croppie": "^2.6.5",
     "dayjs": "^1.11.10",
     "expo-server-sdk": "^3.7.0",

--- a/package.json
+++ b/package.json
@@ -108,7 +108,8 @@
     "tailwind-merge": "^2.2.0",
     "theme-change": "^2.5.0",
     "tiptap-markdown": "^0.8.8",
-    "uuid": "^9.0.1"
+    "uuid": "^9.0.1",
+    "vite-plugin-cjs-interop": "^2.1.0"
   },
   "pnpm": {
     "patchedDependencies": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@types/uuid": "^9.0.8",
     "@typescript-eslint/eslint-plugin": "^6.15.0",
     "@typescript-eslint/parser": "^6.15.0",
+    "@zenstackhq/openapi": "^1.11.1",
     "autoprefixer": "^10.4.16",
     "concurrently": "^8.2.2",
     "daisyui": "^4.4.24",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,8 +47,11 @@ dependencies:
     specifier: ^1.0.10
     version: 1.0.10(@sveltejs/kit@2.4.3)(svelte@4.2.8)
   '@zenstackhq/runtime':
-    specifier: ^1.7.1
-    version: 1.7.1
+    specifier: ^1.11.1
+    version: 1.11.1
+  '@zenstackhq/server':
+    specifier: ^1.11.1
+    version: 1.11.1
   croppie:
     specifier: ^2.6.5
     version: 2.6.5
@@ -84,7 +87,7 @@ dependencies:
     version: 0.33.1
   stripe:
     specifier: ^14.24.0
-    version: 14.24.0
+    version: 14.25.0
   svelte-easy-crop:
     specifier: ^2.0.2
     version: 2.0.2(svelte@4.2.8)
@@ -226,8 +229,8 @@ devDependencies:
     specifier: ^1.3.1
     version: 1.3.1(typescript@5.3.3)(vitest@1.2.2)
   zenstack:
-    specifier: ^1.7.1
-    version: 1.7.1
+    specifier: ^1.11.1
+    version: 1.11.1
   zod:
     specifier: ^3.22.4
     version: 3.22.4
@@ -1433,10 +1436,6 @@ packages:
       - supports-color
     dev: true
 
-  /@prisma/debug@5.12.1:
-    resolution: {integrity: sha512-kd/wNsR0klrv79o1ITsbWxYyh4QWuBidvxsXSParPsYSu0ircUmNk3q4ojsgNc3/81b0ozg76iastOG43tbf8A==}
-    dev: true
-
   /@prisma/debug@5.7.1:
     resolution: {integrity: sha512-yrVSO/YZOxdeIxcBtZ5BaNqUfPrZkNsAKQIQg36cJKMxj/VYK3Vk5jMKkI+gQLl0KReo1YvX8GWKfV788SELjw==}
     dev: false
@@ -1445,27 +1444,17 @@ packages:
     resolution: {integrity: sha512-tjuw7eA0Us3T42jx9AmAgL58rzwzpFGYc3R7Y4Ip75EBYrKMBA1YihuWMcBC92ILmjlQ/u3p8VxcIE0hr+fZfg==}
     dev: true
 
-  /@prisma/engines-version@5.12.0-21.473ed3124229e22d881cb7addf559799debae1ab:
-    resolution: {integrity: sha512-6yvO8s80Tym61aB4QNtYZfWVmE3pwqe807jEtzm8C5VDe7nw8O1FGX3TXUaXmWV0fQTIAfRbeL2Gwrndabp/0g==}
-    dev: true
-
   /@prisma/engines-version@5.7.1-1.0ca5ccbcfa6bdc81c003cf549abe4269f59c41e5:
     resolution: {integrity: sha512-dIR5IQK/ZxEoWRBDOHF87r1Jy+m2ih3Joi4vzJRP+FOj5yxCwS2pS5SBR3TWoVnEK1zxtLI/3N7BjHyGF84fgw==}
     dev: false
 
+  /@prisma/engines-version@5.8.1-1.78caf6feeaed953168c64e15a249c3e9a033ebe2:
+    resolution: {integrity: sha512-f5C3JM3l9yhGr3cr4FMqWloFaSCpNpMi58Om22rjD2DOz3owci2mFdFXMgnAGazFPKrCbbEhcxdsRfspEYRoFQ==}
+    dev: true
+
   /@prisma/engines@4.16.2:
     resolution: {integrity: sha512-vx1nxVvN4QeT/cepQce68deh/Turxy5Mr+4L4zClFuK1GlxN3+ivxfuv+ej/gvidWn1cE1uAhW7ALLNlYbRUAw==}
     requiresBuild: true
-    dev: true
-
-  /@prisma/engines@5.12.1:
-    resolution: {integrity: sha512-HQDdglLw2bZR/TXD2Y+YfDMvi5Q8H+acbswqOsWyq9pPjBLYJ6gzM+ptlTU/AV6tl0XSZLU1/7F4qaWa8bqpJA==}
-    requiresBuild: true
-    dependencies:
-      '@prisma/debug': 5.12.1
-      '@prisma/engines-version': 5.12.0-21.473ed3124229e22d881cb7addf559799debae1ab
-      '@prisma/fetch-engine': 5.12.1
-      '@prisma/get-platform': 5.12.1
     dev: true
 
   /@prisma/engines@5.7.1:
@@ -1477,6 +1466,16 @@ packages:
       '@prisma/fetch-engine': 5.7.1
       '@prisma/get-platform': 5.7.1
     dev: false
+
+  /@prisma/engines@5.8.1:
+    resolution: {integrity: sha512-TJgYLRrZr56uhqcXO4GmP5be+zjCIHtLDK20Cnfg+o9d905hsN065QOL+3Z0zQAy6YD31Ol4u2kzSfRmbJv/uA==}
+    requiresBuild: true
+    dependencies:
+      '@prisma/debug': 5.8.1
+      '@prisma/engines-version': 5.8.1-1.78caf6feeaed953168c64e15a249c3e9a033ebe2
+      '@prisma/fetch-engine': 5.8.1
+      '@prisma/get-platform': 5.8.1
+    dev: true
 
   /@prisma/fetch-engine@4.16.2:
     resolution: {integrity: sha512-lnCnHcOaNn0kw8qTJbVcNhyfIf5Lus2GFXbj3qpkdKEIB9xLgqkkuTP+35q1xFaqwQ0vy4HFpdRUpFP7njE15g==}
@@ -1503,14 +1502,6 @@ packages:
       - supports-color
     dev: true
 
-  /@prisma/fetch-engine@5.12.1:
-    resolution: {integrity: sha512-qSs3KcX1HKcea1A+hlJVK/ljj0PNIUHDxAayGMvgJBqmaN32P9tCidlKz1EGv6WoRFICYnk3Dd/YFLBwnFIozA==}
-    dependencies:
-      '@prisma/debug': 5.12.1
-      '@prisma/engines-version': 5.12.0-21.473ed3124229e22d881cb7addf559799debae1ab
-      '@prisma/get-platform': 5.12.1
-    dev: true
-
   /@prisma/fetch-engine@5.7.1:
     resolution: {integrity: sha512-9ELauIEBkIaEUpMIYPRlh5QELfoC6pyHolHVQgbNxglaINikZ9w9X7r1TIePAcm05pCNp2XPY1ObQIJW5nYfBQ==}
     dependencies:
@@ -1518,6 +1509,14 @@ packages:
       '@prisma/engines-version': 5.7.1-1.0ca5ccbcfa6bdc81c003cf549abe4269f59c41e5
       '@prisma/get-platform': 5.7.1
     dev: false
+
+  /@prisma/fetch-engine@5.8.1:
+    resolution: {integrity: sha512-+bgjjoSFa6uYEbAPlklfoVSStOEfcpheOjoBoNsNNSQdSzcwE2nM4Q0prun0+P8/0sCHo18JZ9xqa8gObvgOUw==}
+    dependencies:
+      '@prisma/debug': 5.8.1
+      '@prisma/engines-version': 5.8.1-1.78caf6feeaed953168c64e15a249c3e9a033ebe2
+      '@prisma/get-platform': 5.8.1
+    dev: true
 
   /@prisma/generator-helper@4.16.2:
     resolution: {integrity: sha512-bMOH7y73Ui7gpQrioFeavMQA+Tf8ksaVf8Nhs9rQNzuSg8SSV6E9baczob0L5KGZTSgYoqnrRxuo03kVJYrnIg==}
@@ -1528,12 +1527,6 @@ packages:
       kleur: 4.1.5
     transitivePeerDependencies:
       - supports-color
-    dev: true
-
-  /@prisma/generator-helper@5.12.1:
-    resolution: {integrity: sha512-TlaI4J6jDKO06P68ve5czz1SionzI5ciUIw2tWFO4FM4qPID5+7nrxTVlecFTUD7Nc+IaO1hYT1YBOPKLiUncQ==}
-    dependencies:
-      '@prisma/debug': 5.12.1
     dev: true
 
   /@prisma/generator-helper@5.8.1:
@@ -1559,17 +1552,17 @@ packages:
       - supports-color
     dev: true
 
-  /@prisma/get-platform@5.12.1:
-    resolution: {integrity: sha512-pgIR+pSvhYHiUcqXVEZS31NrFOTENC9yFUdEAcx7cdQBoZPmHVjtjN4Ss6NzVDMYPrKJJ51U14EhEoeuBlMioQ==}
-    dependencies:
-      '@prisma/debug': 5.12.1
-    dev: true
-
   /@prisma/get-platform@5.7.1:
     resolution: {integrity: sha512-eDlswr3a1m5z9D/55Iyt/nZqS5UpD+DZ9MooBB3hvrcPhDQrcf9m4Tl7buy4mvAtrubQ626ECtb8c6L/f7rGSQ==}
     dependencies:
       '@prisma/debug': 5.7.1
     dev: false
+
+  /@prisma/get-platform@5.8.1:
+    resolution: {integrity: sha512-wnA+6HTFcY+tkykMokix9GiAkaauPC5W/gg0O5JB0J8tCTNWrqpnQ7AsaGRfkYUbeOIioh6woDjQrGTTRf1Zag==}
+    dependencies:
+      '@prisma/debug': 5.8.1
+    dev: true
 
   /@prisma/internals@4.16.2:
     resolution: {integrity: sha512-/3OiSADA3RRgsaeEE+MDsBgL6oAMwddSheXn6wtYGUnjERAV/BmF5bMMLnTykesQqwZ1s8HrISrJ0Vf6cjOxMg==}
@@ -1622,15 +1615,15 @@ packages:
       - supports-color
     dev: true
 
-  /@prisma/internals@5.12.1:
-    resolution: {integrity: sha512-g6j9KebTSPVfGs3s9V6ImaDiTGBSAwVlde98wmvTFJzineVTclrCbmYmqnZKtPE9PLKUJXPsQVIDL/P9/dENbw==}
+  /@prisma/internals@5.8.1:
+    resolution: {integrity: sha512-9okoCgLeMqql58IbEG3YmzgNLRUQdN+qZUYp2DojWC7VAmL9TSOKQ5Dcc0588cKAsCBBDUQ2jfdflorYkzeFKw==}
     dependencies:
-      '@prisma/debug': 5.12.1
-      '@prisma/engines': 5.12.1
-      '@prisma/fetch-engine': 5.12.1
-      '@prisma/generator-helper': 5.12.1
-      '@prisma/get-platform': 5.12.1
-      '@prisma/prisma-schema-wasm': 5.12.0-21.473ed3124229e22d881cb7addf559799debae1ab
+      '@prisma/debug': 5.8.1
+      '@prisma/engines': 5.8.1
+      '@prisma/fetch-engine': 5.8.1
+      '@prisma/generator-helper': 5.8.1
+      '@prisma/get-platform': 5.8.1
+      '@prisma/prisma-schema-wasm': 5.8.1-1.78caf6feeaed953168c64e15a249c3e9a033ebe2
       arg: 5.0.2
       prompts: 2.4.2
     dev: true
@@ -1639,8 +1632,8 @@ packages:
     resolution: {integrity: sha512-g090+dEH7wrdCw359+8J9+TGH84qK28V/dxwINjhhNCtju9lej99z9w/AVsJP9UhhcCPS4psYz4iu8d53uxVpA==}
     dev: true
 
-  /@prisma/prisma-schema-wasm@5.12.0-21.473ed3124229e22d881cb7addf559799debae1ab:
-    resolution: {integrity: sha512-93HT3McC6z6a+2mmHLZVjLz0M0YR4t0CZcsq4HnU0aMWwC9CottwDZvABIPacWqPSXb+5ZnTVybgpZ+Cj1i0rA==}
+  /@prisma/prisma-schema-wasm@5.8.1-1.78caf6feeaed953168c64e15a249c3e9a033ebe2:
+    resolution: {integrity: sha512-UAJANliORe2V/s7yDMx5EKOCj2PIbwX7yusKckxMBDb+ozaQF31c3CBwnZW/ZEdhBoZjrKw8bQlqwZudWXmiKA==}
     dev: true
 
   /@remirror/core-constants@2.0.2:
@@ -2520,14 +2513,14 @@ packages:
       pretty-format: 29.7.0
     dev: true
 
-  /@zenstackhq/language@1.7.1:
-    resolution: {integrity: sha512-K4iT/Xf2rXe2z+V3bw0AlWug9WiGnDlR+FcnaAWy09ps3A+p9SweO2NbH6dL5wEcLccSv8YkThR+3utl5k+ErA==}
+  /@zenstackhq/language@1.11.1:
+    resolution: {integrity: sha512-ymskplh9xn4SlMTcZr4pT+js3S0/hpL0DqqQdNkChYFy8HgqsRlDEciWJLxCwOgAfxH2DXm1UJGfKqNmE0XzvA==}
     dependencies:
-      langium: 1.2.0
+      langium: 1.3.1
     dev: true
 
-  /@zenstackhq/runtime@1.7.1:
-    resolution: {integrity: sha512-eEcdNKUb4ez+r5TMxFn7iEz1WxunPMM9gNiK0Rt2CIbsqvPT6Zb5Fu3RZenn099mMGIXOiNie+gwDS3ejc7jUQ==}
+  /@zenstackhq/runtime@1.11.1:
+    resolution: {integrity: sha512-8RhE4glC1Fk5F8W9sjZ0W491jEAssWnS0tcjy/5fzd8VraMmzElHpSQcJmlGD2gYeo9iIU9iwEsgP0fdjWG7SA==}
     dependencies:
       '@types/bcryptjs': 2.4.6
       bcryptjs: 2.4.3
@@ -2547,14 +2540,14 @@ packages:
       zod: 3.22.4
       zod-validation-error: 1.5.0(zod@3.22.4)
 
-  /@zenstackhq/sdk@1.7.1:
-    resolution: {integrity: sha512-O98yOfct9M8yX1z3OjDYjE1gD0k0gUxtKsTsXPNe5vJIvuauETnwFPwyHh8RMExl2ZbMY7RrpPZ7TzUWuwuTew==}
+  /@zenstackhq/sdk@1.11.1:
+    resolution: {integrity: sha512-NIyroIKHJkxpQWr5op7aPhB+sZOeXNcfSIjH91gaDhit20wQBu0bd1FBfDBlYvIPG6BYitWWC7uy5UU2Eys9NQ==}
     dependencies:
       '@prisma/generator-helper': 5.8.1
       '@prisma/internals': 4.16.2
-      '@prisma/internals-v5': /@prisma/internals@5.12.1
-      '@zenstackhq/language': 1.7.1
-      '@zenstackhq/runtime': 1.7.1
+      '@prisma/internals-v5': /@prisma/internals@5.8.1
+      '@zenstackhq/language': 1.11.1
+      '@zenstackhq/runtime': 1.11.1
       lower-case-first: 2.0.2
       prettier: 3.1.1
       semver: 7.5.4
@@ -2564,6 +2557,21 @@ packages:
       - encoding
       - supports-color
     dev: true
+
+  /@zenstackhq/server@1.11.1:
+    resolution: {integrity: sha512-qs88p9PnCnbaQPyASw+ebNW6QFtOttuPUYSbzDZv0qmesX6xUsXUSddDIV54bJYD43ztdDgJyFb/fq2mxJX5KA==}
+    dependencies:
+      '@zenstackhq/runtime': 1.11.1
+      change-case: 4.1.2
+      lower-case-first: 2.0.2
+      superjson: 1.13.3
+      tiny-invariant: 1.3.1
+      ts-japi: 1.10.0
+      upper-case-first: 2.0.2
+      url-pattern: 1.0.3
+      zod: 3.22.4
+      zod-validation-error: 1.5.0(zod@3.22.4)
+    dev: false
 
   /@zxing/text-encoding@0.9.0:
     resolution: {integrity: sha512-U/4aVJ2mxI0aDNI8Uq0wEhMgY+u4CNtEb0om3+y3+niDAsoTCOB33UF0sxpzqzdqXLqmvc+vZyAt4O8pPdfkwA==}
@@ -2791,7 +2799,7 @@ packages:
       postcss: ^8.1.0
     dependencies:
       browserslist: 4.21.11
-      caniuse-lite: 1.0.30001611
+      caniuse-lite: 1.0.30001538
       fraction.js: 4.3.6
       normalize-range: 0.1.2
       picocolors: 1.0.0
@@ -2807,7 +2815,7 @@ packages:
   /axios@1.6.5:
     resolution: {integrity: sha512-Ii012v05KEVuUoFWmMW/UQv9aRIc3ZwkWDcM+h5Il8izZCtRVpDUfwpoFf7eOtajT3QiGR4yDUx7lPqHJULgbg==}
     dependencies:
-      follow-redirects: 1.15.6(debug@4.3.4)
+      follow-redirects: 1.15.4(debug@4.3.4)
       form-data: 4.0.0
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
@@ -2887,7 +2895,7 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
     dependencies:
-      caniuse-lite: 1.0.30001611
+      caniuse-lite: 1.0.30001538
       electron-to-chromium: 1.4.528
       node-releases: 2.0.13
       update-browserslist-db: 1.0.13(browserslist@4.21.11)
@@ -2966,8 +2974,8 @@ packages:
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     dev: false
 
-  /caniuse-lite@1.0.30001611:
-    resolution: {integrity: sha512-19NuN1/3PjA3QI8Eki55N8my4LzfkMCRLgCVfrl/slbSAchQfV0+GwjPrK3rq37As4UCLlM/DHajbKkAqbv92Q==}
+  /caniuse-lite@1.0.30001538:
+    resolution: {integrity: sha512-HWJnhnID+0YMtGlzcp3T9drmBJUVDchPJ08tpUGFLs9CYlwWPH2uLgpHn8fND5pCgXVtnGS3H4QR9XLMHVNkHw==}
     dev: true
 
   /capital-case@1.0.4:
@@ -4002,8 +4010,8 @@ packages:
     resolution: {integrity: sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==}
     dev: true
 
-  /follow-redirects@1.15.6(debug@4.3.4):
-    resolution: {integrity: sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==}
+  /follow-redirects@1.15.4(debug@4.3.4):
+    resolution: {integrity: sha512-Cr4D/5wlrb0z9dgERpUL3LrmPKVDsETIJhaCMeDfuFYcqa5bldGV6wBsAN6X/vxlXQtFBMrXdXxdL8CbDTGniw==}
     engines: {node: '>=4.0'}
     peerDependencies:
       debug: '*'
@@ -4137,7 +4145,7 @@ packages:
     dependencies:
       debug: 4.3.4
       decompress-response: 7.0.0
-      follow-redirects: 1.15.6(debug@4.3.4)
+      follow-redirects: 1.15.4(debug@4.3.4)
       into-stream: 6.0.0
       is-plain-object: 5.0.0
       is-retry-allowed: 2.2.0
@@ -4861,8 +4869,8 @@ packages:
     resolution: {integrity: sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ==}
     dev: false
 
-  /langium@1.2.0:
-    resolution: {integrity: sha512-jFSptpFljYo9ZTHrq/GZflMUXiKo5KBNtsaIJtnIzDm9zC2FxsxejEFAtNL09262RVQt+zFeF/2iLAShFTGitw==}
+  /langium@1.3.1:
+    resolution: {integrity: sha512-xC+DnAunl6cZIgYjRpgm3s1kYAB5/Wycsj24iYaXG9uai7SgvMaFZSrRvdA5rUK/lSta/CRvgF+ZFoEKEOFJ5w==}
     engines: {node: '>=14.0.0'}
     dependencies:
       chevrotain: 10.4.2
@@ -5052,6 +5060,13 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       '@jridgewell/sourcemap-codec': 1.4.15
+
+  /magic-string@0.30.9:
+    resolution: {integrity: sha512-S1+hd+dIrC8EZqKyT9DstTH/0Z+f76kmmvZnkfQVmOpDEF9iVgdYif3Q/pIWHmCoo59bQVGW0kVL3e2nl+9+Sw==}
+    engines: {node: '>=12'}
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.4.15
+    dev: true
 
   /make-dir@3.1.0:
     resolution: {integrity: sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==}
@@ -5310,10 +5325,6 @@ packages:
   /node-gyp-build@4.6.1:
     resolution: {integrity: sha512-24vnklJmyRS8ViBNI8KbtK/r/DmXQMRiOMXTNz2nrTnAYUwjmEEbnnpB/+kt+yWRv73bPsSPRFddrcIbAxSiMQ==}
     hasBin: true
-    dev: true
-
-  /node-machine-id@1.1.12:
-    resolution: {integrity: sha512-QNABxbrPa3qEIfrE6GOJ7BYIuignnJw7iQ2YPbc3Nla1HzRJjXzZOiikfF8m7eAMfichLt3M4VgLOetqgDmgGQ==}
     dev: true
 
   /node-releases@2.0.13:
@@ -6178,8 +6189,8 @@ packages:
     engines: {node: '>=6'}
     dev: false
 
-  /qs@6.12.0:
-    resolution: {integrity: sha512-trVZiI6RMOkO476zLGaBIzszOdFPnCCXHPG9kn0yuS1uz6xdVxPfZdB3vUig9pxPFDM9BRAgz/YUIVQ1/vuiUg==}
+  /qs@6.12.1:
+    resolution: {integrity: sha512-zWmv4RSuB9r2mYQw3zxQuHWeU+42aKi1wWig/j4ele4ygELZ7PEO6MM7rim9oAQH2A5MWfsAVf/jPvTPgCbvUQ==}
     engines: {node: '>=0.6'}
     dependencies:
       side-channel: 1.0.6
@@ -6779,12 +6790,12 @@ packages:
       acorn: 8.11.3
     dev: true
 
-  /stripe@14.24.0:
-    resolution: {integrity: sha512-r0JWz2quThXsFbp1pevkAAoDk4sw3kFMQEc2qvxMFUOhw/SFGqtAGz4vQgP/fMWzO28ljBNEiz68KqRx0JS3dw==}
+  /stripe@14.25.0:
+    resolution: {integrity: sha512-wQS3GNMofCXwH8TSje8E1SE8zr6ODiGtHQgPtO95p9Mb4FhKC9jvXR2NUTpZ9ZINlckJcFidCmaTFV4P6vsb9g==}
     engines: {node: '>=12.*'}
     dependencies:
       '@types/node': 20.10.5
-      qs: 6.12.0
+      qs: 6.12.1
     dev: false
 
   /strnum@1.0.5:
@@ -6943,7 +6954,7 @@ packages:
     dependencies:
       '@types/pug': 2.0.6
       detect-indent: 6.1.0
-      magic-string: 0.30.5
+      magic-string: 0.30.9
       postcss: 8.4.32
       sorcery: 0.11.0
       strip-indent: 3.0.0
@@ -7231,8 +7242,8 @@ packages:
       typescript: 5.3.3
     dev: true
 
-  /ts-essentials@9.4.1(typescript@5.3.3):
-    resolution: {integrity: sha512-oke0rI2EN9pzHsesdmrOrnqv1eQODmJpd/noJjwj2ZPC3Z4N2wbjrOEqnsEgmvlO2+4fBb0a794DCna2elEVIQ==}
+  /ts-essentials@9.4.2(typescript@5.3.3):
+    resolution: {integrity: sha512-mB/cDhOvD7pg3YCLk2rOtejHjjdSi9in/IBYE13S+8WA5FBSraYf4V/ws55uvs0IvQ/l0wBOlXy5yBNZ9Bl8ZQ==}
     peerDependencies:
       typescript: '>=4.1.0'
     peerDependenciesMeta:
@@ -7244,6 +7255,11 @@ packages:
 
   /ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
+
+  /ts-japi@1.10.0:
+    resolution: {integrity: sha512-va43oA/a/vfHuGRbQ1A+4CKo16XBInTUeDA/yISv3Ai1S8cGLgnG56VTy/Og4mZ3HRjZMDUTzNK3Twun6Snrtg==}
+    engines: {node: '>=10'}
+    dev: false
 
   /ts-morph@16.0.0:
     resolution: {integrity: sha512-jGNF0GVpFj0orFw55LTsQxVYEUOCWBAbR5Ls7fTYE5pQsbW18ssTb/6UXx/GYAEjS+DQTp8VoTw0vqYMiaaQuw==}
@@ -7399,6 +7415,11 @@ packages:
       requires-port: 1.0.0
     dev: false
 
+  /url-pattern@1.0.3:
+    resolution: {integrity: sha512-uQcEj/2puA4aq1R3A2+VNVBgaWYR24FdWjl7VNW83rnWftlhyzOZ/tBjezRiC2UkIzuxC8Top3IekN3vUf1WxA==}
+    engines: {node: '>=0.12.0'}
+    dev: false
+
   /url-template@3.1.1:
     resolution: {integrity: sha512-4oszoaEKE/mQOtAmdMWqIRHmkxWkUZMnXFnjQ5i01CuRSK3uluxcH1MRVVVWmhlnzT1SCDfKxxficm2G37qzCA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -7532,7 +7553,7 @@ packages:
       typescript: 3.x || 4.x || 5.x
       vitest: '>=0.31.1'
     dependencies:
-      ts-essentials: 9.4.1(typescript@5.3.3)
+      ts-essentials: 9.4.2(typescript@5.3.3)
       typescript: 5.3.3
       vitest: 1.2.2(@types/node@20.10.5)
     dev: true
@@ -7867,25 +7888,24 @@ packages:
     engines: {node: '>=12.20'}
     dev: true
 
-  /zenstack@1.7.1:
-    resolution: {integrity: sha512-m6pctZgoC7iOiHM78JCFGcwlu1lyFVscI9KrdlaUN6jaK0VAAeQLQUyEMvK68fcGnmENdahU/ID6eOeGbKafRA==}
+  /zenstack@1.11.1:
+    resolution: {integrity: sha512-CY2UHxVxkJxmga+u36eEEE5q7JWf2voiL2lnV9o9X4l+FI6nT74pgKewCf7hHLTzD5dHKplqpjfQHgm99P2Bvg==}
     engines: {vscode: ^1.56.0}
     hasBin: true
     requiresBuild: true
     dependencies:
       '@paralleldrive/cuid2': 2.2.2
       '@prisma/generator-helper': 5.8.1
-      '@zenstackhq/language': 1.7.1
-      '@zenstackhq/sdk': 1.7.1
+      '@zenstackhq/language': 1.11.1
+      '@zenstackhq/sdk': 1.11.1
       async-exit-hook: 2.0.1
       change-case: 4.1.2
       colors: 1.4.0
       commander: 8.3.0
       get-latest-version: 5.1.0
-      langium: 1.2.0
+      langium: 1.3.1
       lower-case-first: 2.0.2
       mixpanel: 0.17.0
-      node-machine-id: 1.1.12
       ora: 5.4.1
       pluralize: 8.0.0
       pretty-repl: 4.0.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,6 +106,9 @@ dependencies:
   uuid:
     specifier: ^9.0.1
     version: 9.0.1
+  vite-plugin-cjs-interop:
+    specifier: ^2.1.0
+    version: 2.1.0
 
 devDependencies:
   '@clack/prompts':
@@ -158,7 +161,7 @@ devDependencies:
     version: 6.15.0(eslint@8.56.0)(typescript@5.3.3)
   '@zenstackhq/openapi':
     specifier: ^1.11.1
-    version: 1.11.1
+    version: 1.12.3
   autoprefixer:
     specifier: ^10.4.16
     version: 10.4.16(postcss@8.4.32)
@@ -2522,12 +2525,18 @@ packages:
       langium: 1.3.1
     dev: true
 
-  /@zenstackhq/openapi@1.11.1:
-    resolution: {integrity: sha512-W/fs2g3aoFri8sMhGDLg6SQRsc5oKwVTLjY6OpX8TtlYEJuzTzYZ5KPalb6CZmyGR3rFzNC8J0Gv0u3nikrQWA==}
+  /@zenstackhq/language@1.12.3:
+    resolution: {integrity: sha512-QmRS2abDhXMJP6iyVmaUNOV+m4xlTZu74IBS5/r/Jp2qfvNmp9uZ5grO6gED2K6m11TT5U+opZU6zYByYvlJhQ==}
+    dependencies:
+      langium: 1.3.1
+    dev: true
+
+  /@zenstackhq/openapi@1.12.3:
+    resolution: {integrity: sha512-n+QuFuO13DWTYc7ALEpj+bE4Qzq8xBG/aKsLbQQczfeEUaFyF+VF5lZyPsuk1OSH2Dw28EUgjq2pv9ccpo8pyg==}
     dependencies:
       '@prisma/generator-helper': 5.8.1
-      '@zenstackhq/runtime': 1.11.1
-      '@zenstackhq/sdk': 1.11.1
+      '@zenstackhq/runtime': 1.12.3
+      '@zenstackhq/sdk': 1.12.3
       change-case: 4.1.2
       lower-case-first: 2.0.2
       openapi-types: 12.1.3
@@ -2564,6 +2573,28 @@ packages:
       zod: 3.22.4
       zod-validation-error: 1.5.0(zod@3.22.4)
 
+  /@zenstackhq/runtime@1.12.3:
+    resolution: {integrity: sha512-t2ozYppcMsSlvaiJtzrgUurQ7/sViRLIdDGEw4KKbLhWCBFOohfQaKZkr5xcFPHMHPWI2Mjt6TDHHVOoTyafYQ==}
+    dependencies:
+      '@types/bcryptjs': 2.4.6
+      bcryptjs: 2.4.3
+      buffer: 6.0.3
+      change-case: 4.1.2
+      colors: 1.4.0
+      decimal.js: 10.4.3
+      deepcopy: 2.1.0
+      lower-case-first: 2.0.2
+      pluralize: 8.0.0
+      semver: 7.5.4
+      superjson: 1.13.3
+      tiny-invariant: 1.3.1
+      tslib: 2.6.2
+      upper-case-first: 2.0.2
+      uuid: 9.0.1
+      zod: 3.22.4
+      zod-validation-error: 1.5.0(zod@3.22.4)
+    dev: true
+
   /@zenstackhq/sdk@1.11.1:
     resolution: {integrity: sha512-NIyroIKHJkxpQWr5op7aPhB+sZOeXNcfSIjH91gaDhit20wQBu0bd1FBfDBlYvIPG6BYitWWC7uy5UU2Eys9NQ==}
     dependencies:
@@ -2572,6 +2603,24 @@ packages:
       '@prisma/internals-v5': /@prisma/internals@5.8.1
       '@zenstackhq/language': 1.11.1
       '@zenstackhq/runtime': 1.11.1
+      lower-case-first: 2.0.2
+      prettier: 3.1.1
+      semver: 7.5.4
+      ts-morph: 16.0.0
+      upper-case-first: 2.0.2
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+    dev: true
+
+  /@zenstackhq/sdk@1.12.3:
+    resolution: {integrity: sha512-7vAYLyc1LkaAiLo5vp81DO01Mq+ltJ6pIelwHYNFzTYiX65OGDRi3SN0hF+EVZwv16wCJVjY93hBv2PmtS7dVg==}
+    dependencies:
+      '@prisma/generator-helper': 5.8.1
+      '@prisma/internals': 4.16.2
+      '@prisma/internals-v5': /@prisma/internals@5.8.1
+      '@zenstackhq/language': 1.12.3
+      '@zenstackhq/runtime': 1.12.3
       lower-case-first: 2.0.2
       prettier: 3.1.1
       semver: 7.5.4
@@ -2607,6 +2656,14 @@ packages:
     resolution: {integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==}
     dev: true
 
+  /acorn-import-assertions@1.9.0(acorn@8.11.3):
+    resolution: {integrity: sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==}
+    peerDependencies:
+      acorn: ^8
+    dependencies:
+      acorn: 8.11.3
+    dev: false
+
   /acorn-import-attributes@1.9.2(acorn@8.10.0):
     resolution: {integrity: sha512-O+nfJwNolEA771IYJaiLWK1UAwjNsQmZbTRqqwBYxCgVQTmpFEMvBw6LOIQV0Me339L5UMVYFyRohGnGlQDdIQ==}
     peerDependencies:
@@ -2637,7 +2694,6 @@ packages:
     resolution: {integrity: sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==}
     engines: {node: '>=0.4.0'}
     hasBin: true
-    dev: true
 
   /agent-base@6.0.2:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
@@ -2902,7 +2958,6 @@ packages:
     resolution: {integrity: sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==}
     dependencies:
       balanced-match: 1.0.2
-    dev: true
 
   /braces@3.0.2:
     resolution: {integrity: sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==}
@@ -5090,7 +5145,6 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       '@jridgewell/sourcemap-codec': 1.4.15
-    dev: true
 
   /make-dir@3.1.0:
     resolution: {integrity: sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==}
@@ -5199,6 +5253,13 @@ packages:
     dependencies:
       brace-expansion: 2.0.1
     dev: true
+
+  /minimatch@9.0.4:
+    resolution: {integrity: sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    dependencies:
+      brace-expansion: 2.0.1
+    dev: false
 
   /minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
@@ -7529,6 +7590,16 @@ packages:
       - supports-color
       - terser
     dev: true
+
+  /vite-plugin-cjs-interop@2.1.0:
+    resolution: {integrity: sha512-qp+54VPRKiiuqKZ4tToiEZz5d5uiZf33PrXOfyH5SInlVsYz4b6YoZMNxCrx+vKdAQVsZu03vDJK71Ri5oKMqg==}
+    dependencies:
+      acorn: 8.11.3
+      acorn-import-assertions: 1.9.0(acorn@8.11.3)
+      estree-walker: 3.0.3
+      magic-string: 0.30.9
+      minimatch: 9.0.4
+    dev: false
 
   /vite@5.0.12(@types/node@20.10.5):
     resolution: {integrity: sha512-4hsnEkG3q0N4Tzf1+t6NdN9dg/L3BM+q8SWgbSPnJvrgH2kgdyzfVJwbR1ic69/4uMJJ/3dqDZZE5/WwqW8U1w==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -156,6 +156,9 @@ devDependencies:
   '@typescript-eslint/parser':
     specifier: ^6.15.0
     version: 6.15.0(eslint@8.56.0)(typescript@5.3.3)
+  '@zenstackhq/openapi':
+    specifier: ^1.11.1
+    version: 1.11.1
   autoprefixer:
     specifier: ^10.4.16
     version: 10.4.16(postcss@8.4.32)
@@ -2517,6 +2520,27 @@ packages:
     resolution: {integrity: sha512-ymskplh9xn4SlMTcZr4pT+js3S0/hpL0DqqQdNkChYFy8HgqsRlDEciWJLxCwOgAfxH2DXm1UJGfKqNmE0XzvA==}
     dependencies:
       langium: 1.3.1
+    dev: true
+
+  /@zenstackhq/openapi@1.11.1:
+    resolution: {integrity: sha512-W/fs2g3aoFri8sMhGDLg6SQRsc5oKwVTLjY6OpX8TtlYEJuzTzYZ5KPalb6CZmyGR3rFzNC8J0Gv0u3nikrQWA==}
+    dependencies:
+      '@prisma/generator-helper': 5.8.1
+      '@zenstackhq/runtime': 1.11.1
+      '@zenstackhq/sdk': 1.11.1
+      change-case: 4.1.2
+      lower-case-first: 2.0.2
+      openapi-types: 12.1.3
+      semver: 7.5.4
+      tiny-invariant: 1.3.1
+      ts-pattern: 4.3.0
+      upper-case-first: 2.0.2
+      yaml: 2.3.2
+      zod: 3.22.4
+      zod-validation-error: 1.5.0(zod@3.22.4)
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
     dev: true
 
   /@zenstackhq/runtime@1.11.1:
@@ -5490,6 +5514,10 @@ packages:
     dependencies:
       is-docker: 2.2.1
       is-wsl: 2.2.0
+    dev: true
+
+  /openapi-types@12.1.3:
+    resolution: {integrity: sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==}
     dev: true
 
   /optionator@0.9.3:

--- a/src/database/schema.zmodel
+++ b/src/database/schema.zmodel
@@ -12,7 +12,7 @@ datasource db {
 
 plugin openapi {
   provider = '@zenstackhq/openapi'
-  output = './openapi.yaml'
+  output = '../routes/api/openapi.json/openapi.json'
   title = 'D-sektionen API'
   version = '1.0.0'
   prefix = '/api/model'

--- a/src/database/schema.zmodel
+++ b/src/database/schema.zmodel
@@ -10,6 +10,14 @@ datasource db {
   directUrl = env("POSTGRES_URL_NON_POOLING") // uses a direct connection
 }
 
+plugin openapi {
+  provider = '@zenstackhq/openapi'
+  output = './openapi.yaml'
+  title = 'D-sektionen API'
+  version = '1.0.0'
+  prefix = '/api/model'
+}
+
 model User {
   studentId String @id
   memberId String

--- a/src/routes/api/openapi.json/+server.ts
+++ b/src/routes/api/openapi.json/+server.ts
@@ -1,0 +1,12 @@
+import type { RequestHandler } from "./$types";
+import openapi from "./openapi.json";
+
+const openapiString = JSON.stringify(openapi);
+
+export const GET: RequestHandler = () => {
+  return new Response(openapiString, {
+    headers: {
+      "Content-Type": "application/json",
+    },
+  });
+};

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,6 @@
 import { paraglide } from "@inlang/paraglide-js-adapter-sveltekit/vite";
 import { sveltekit } from "@sveltejs/kit/vite";
+import { cjsInterop } from "vite-plugin-cjs-interop";
 import { defineConfig } from "vite";
 
 export default defineConfig({
@@ -8,6 +9,9 @@ export default defineConfig({
     paraglide({
       project: "./project.inlang",
       outdir: "./src/translations/paraglide",
+    }),
+    cjsInterop({
+      dependencies: ["@zenstackhq/server/**"],
     }),
   ],
 });


### PR DESCRIPTION
This PR adds an automatically generated RPC-style API using ZenStack. This allows anyone to read basically any data from our database, provided that they are authorized to do so - the same authorization rules as for our normal database reads apply. I also added OpenAPI documentation that can be used, for instance, to build a Swagger UI to explore our API. 

I have been postponing this PR because there are a lot of things to consider:
- **Do we want to commit to maintaining an API?** Of course it seems trivial right now since it's automatically generated, but what if it breaks? What if we one day want to move away from Prisma and therefore can't use ZenStack to generate an API for us? By opening up an API we're implicitly commiting to maintaining it, at least if people begin building tools based on it.
- **What does support of third-party applications even look like?** Some members may choose to build private tools on this API and that's fine, but others may be build tools used by a wider audience. Should we provide this audience by integrating third-party tools inside the main dsek.se website? I could imagine a "widget" page where users could submit their custom widgets.
In fact, there are probably a few tools right now that could benefit from being integrated on the main dsek.se site (i.e gerda.dsek.se), and by creating an API we are further encouraging this. I think that's awesome! But we don't currently have an infrastructure that supports this. I have been looking at technologies such as [Webpack Module Federation](https://webpack.js.org/concepts/module-federation/) (and its Rollup (Vite) equivalents) that allow runtime integration of third-party code, but we currently have no idea if that's something we want to build upon.
- **Should we provide API documentation?** If we want people to use this then obviously yes. I tried adding interactive API documentation to this PR (using Swagger UI), but I couldn't make it performant enough (the API specification is about 100 000 lines long and there are A LOT of operations; it was either slow or simply crashed).
- **Is RPC och REST more appropriate?** ZenStack allows us to generate two different flavours of API — one that simulates using the Prisma client directly by providing endpoints such as `events/findMany`, and another that is more of a  "standard REST API". I was initially leaning towards REST, but I was swayed towards RPC when I read that ZenStack can generate frontend query hooks for the RPC API. That's obviously a big selling point if we want people to be able to easily fetch data from us in their third-party JS apps. And if we ever want to build a more native React Native app we could use the queries there too.
- **Should automatically generated code be tracked by Git?** It's perhaps only tangential to this PR, but with all these generated files (openapi.yaml) it feels like an annoyance to have to make sure that all commited changes to schema.zmodel also include changes to all of the derivative files (schema.prisma and openapi.yaml are generated from schema.zmodel).