### PR TITLE
Translate landing page

### DIFF
--- a/src/routes/(app)/CaféOpenTimes.svelte
+++ b/src/routes/(app)/CaféOpenTimes.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type { Markdown } from "@prisma/client";
+  import * as m from "$paraglide/messages";
 
   export let cafeOpen: Pick<Markdown, "markdown"> | null;
 </script>
@@ -11,7 +12,7 @@
   <span class="i-mdi-coffee self-center text-2xl" />
 
   <article>
-    <p>Caféets öppettider</p>
+    <p>{m.landing_cafeOpenHours()}</p>
     <h2 class="text-xl font-bold">
       {#if cafeOpen}
         {cafeOpen.markdown}

--- a/src/routes/(app)/Header.svelte
+++ b/src/routes/(app)/Header.svelte
@@ -1,3 +1,7 @@
+<script lang="ts">
+  import * as m from "$paraglide/messages";
+</script>
+
 <header class="contents">
   <img
     class="h-full w-full object-cover md:col-span-2"
@@ -5,22 +9,19 @@
     alt="Cover"
   />
   <h1 class="text-balance text-5xl font-bold lg:text-6xl">
-    Det <span class="text-primary">roliga</span> med plugget
+    <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+    {@html m.landing_splash()}
   </h1>
   <div>
     <p class="mb-8">
-      <strong>D-sektionen inom TLTH</strong> är en ideell organisation för
-      studenter och alumner vid programmen
-      <span class="text-primary">Datateknik</span> och
-      <span class="text-secondary">InfoCom</span>. Sektionen har sociala
-      arrangemang, näringslivskontakter, studiebevakning, och allt annat som
-      hjälper studenter och alumner.
+      <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+      {@html m.landing_info()}
     </p>
     <a
       class="btn btn-primary justify-self-start rounded-none px-10 font-bold uppercase"
       href="/info/for-foretag"
     >
-      För företag
+      {m.landing_forCompanies()}
     </a>
   </div>
 </header>

--- a/src/routes/(app)/Meetings.svelte
+++ b/src/routes/(app)/Meetings.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type { Meeting } from "@prisma/client";
+  import * as m from "$paraglide/messages";
   export let upcoming: Pick<Meeting, "title"> | null;
   export let previous: Pick<Meeting, "title"> | null;
 </script>
@@ -11,7 +12,7 @@
   <span class="i-mdi-gavel self-center text-2xl" />
 
   <article class="flex-1">
-    <p>Nästa möte</p>
+    <p>{m.landing_meetingNext()}</p>
     <h2 class="text-xl font-bold">
       {#if upcoming}
         {upcoming.title}
@@ -23,7 +24,7 @@
 
   {#if previous}
     <article>
-      <p class="font-light">Senaste möte</p>
+      <p class="font-light">{m.landing_meetingPrev()}</p>
       <h2 class="text-xl font-light">
         {previous.title}
       </h2>

--- a/src/routes/(app)/WellbeingCTA.svelte
+++ b/src/routes/(app)/WellbeingCTA.svelte
@@ -1,3 +1,7 @@
+<script lang="ts">
+  import * as m from "$paraglide/messages";
+</script>
+
 <a
   class="flex cursor-pointer gap-6 bg-base-300 p-6 transition-all duration-200 hover:-translate-x-1 hover:-translate-y-1 hover:bg-base-200 hover:shadow-xl"
   href="https://bit.ly/kontaktatrivsel"
@@ -5,7 +9,7 @@
   <span class="i-mdi-speak self-center text-2xl" />
 
   <article>
-    <p>Tankar eller åsikter?</p>
-    <h2 class="text-xl font-bold">Kontakta Trivselrådet</h2>
+    <p>{m.landing_feedback()}</p>
+    <h2 class="text-xl font-bold">{m.landing_contactWellbeing()}</h2>
   </article>
 </a>

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1,3 +1,11 @@
 {
-  "$schema": "https://inlang.com/schema/inlang-message-format"
+  "$schema": "https://inlang.com/schema/inlang-message-format",
+  "landing_info": "<strong>The D-guild within TLTH</strong> is a non-profit organization for students and alumni of the programs <span class=\"text-primary\">Computer Science</span> and <span class=\"text-secondary\">Information and Communication Technology</span> . The guild has social arrangements, business contacts, study supervision, and everything else that helps students and alumni.",
+  "landing_forCompanies": "For companies",
+  "landing_splash": "Experience the <span class=\"text-primary\">fun</span> of University",
+  "landing_cafeOpenHours": "Café opening hours",
+  "landing_meetingNext": "Next meeting",
+  "landing_meetingPrev": "Previous meeting",
+  "landing_feedback": "Thoughts or opinions?",
+  "landing_contactWellbeing": "Contact the Wellbeing Committee"
 }

--- a/src/translations/sv.json
+++ b/src/translations/sv.json
@@ -1,3 +1,11 @@
 {
-  "$schema": "https://inlang.com/schema/inlang-message-format"
+  "$schema": "https://inlang.com/schema/inlang-message-format",
+  "landing_info": "<strong>D-sektionen inom TLTH</strong> är en ideell organisation för studenter och alumner vid programmen <span class=\"text-primary\">Datateknik</span> och <span class=\"text-secondary\">InfoCom</span>. Sektionen har sociala arrangemang, näringslivskontakter, studiebevakning, och allt annat som hjälper studenter och alumner.",
+  "landing_forCompanies": "För företag",
+  "landing_splash": "Det <span class=\"text-primary\">roliga</span> med plugget",
+  "landing_cafeOpenHours": "Caféets öppettider",
+  "landing_meetingNext": "Nästa möte",
+  "landing_meetingPrev": "Senaste möte",
+  "landing_feedback": "Tankar eller åsikter?",
+  "landing_contactWellbeing": "Kontakta Trivselrådet"
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -4,7 +4,7 @@ import { iconsPlugin, getIconCollections } from "@egoist/tailwindcss-icons";
 export default {
   darkMode: ["class", '[data-theme="dark"]'], // dark mode set by class="dark" or data-theme="dark" in DOM
   mode: "jit",
-  content: ["./src/**/*.{html,js,svelte,ts}"],
+  content: ["./src/**/*.{html,js,json,svelte,ts}"],
   safelist: [
     "alert-error",
     "alert-success",


### PR DESCRIPTION
This pull request implements translations for the landing page. Note that I had to use `@html` to render rich translated text (i.e bold parts in the translated text). I think this will become easier to implement once the paraglide.js library completes [#913](https://github.com/opral/monorepo/discussions/913).