### PR TITLE
Various minor alert fixes

### DIFF
--- a/src/lib/utils/softDelete.ts
+++ b/src/lib/utils/softDelete.ts
@@ -1,0 +1,21 @@
+import { Prisma } from "@prisma/client";
+import { error } from "@sveltejs/kit";
+
+/**
+ * Wrap a soft delete function in a try-catching block.
+ * This is a workaround to known issue with ZenStack: https://github.com/zenstackhq/zenstack/issues/687
+ * @param deleteFn - The function to wrap
+ */
+export default async <T>(deleteFn: () => Promise<T>) => {
+  await deleteFn().catch((e) => {
+    if (e instanceof Prisma.PrismaClientKnownRequestError) {
+      // This means that the operation succeeded, but the result was not readable after the operation.
+      // We don't expect the result to be readable after a delete operation, so we can safely ignore this error.
+      // See https://zenstack.dev/docs/reference/error-handling
+      if (e.code === "P2004" && e?.meta?.["reason"] === "RESULT_NOT_READABLE") {
+        return;
+      }
+    }
+    throw error(500, "Failed to delete record");
+  });
+};

--- a/src/routes/(app)/+layout.server.ts
+++ b/src/routes/(app)/+layout.server.ts
@@ -1,0 +1,9 @@
+export const load = async ({ locals }) => {
+  const { prisma } = locals;
+  const alerts = await prisma.alert.findMany({
+    where: {
+      removedAt: null,
+    },
+  });
+  return { alerts };
+};

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -1,15 +1,26 @@
 <script lang="ts">
+  import GlobalAlert from "$lib/components/GlobalAlert.svelte";
+  import { languageTag } from "$paraglide/runtime";
   import "../../app.css";
   import Drawer from "../Drawer.svelte";
   import Footer from "../Footer.svelte";
   import Navbar from "../Navbar.svelte";
   import Toast from "../Toast.svelte";
+
+  export let data;
 </script>
 
 <nav class="contents">
   <Navbar />
   <Drawer />
 </nav>
+
+{#each data.alerts as alert}
+  <GlobalAlert
+    message={languageTag() === "sv" ? alert.message : alert.messageEn}
+    severity={alert.severity}
+  />
+{/each}
 
 <main class="flex-1">
   <slot />

--- a/src/routes/(app)/+page.server.ts
+++ b/src/routes/(app)/+page.server.ts
@@ -70,19 +70,13 @@ export const load: PageServerLoad = async ({ locals }) => {
       name: `cafe:open:${new Date().getDay() - 1}`, // we assign monday to 0, not sunday
     },
   });
-  const alertPromise = prisma.alert.findMany({
-    where: {
-      removedAt: null,
-    },
-  });
-  const [news, events, upcomingMeeting, previousMeeting, cafeOpen, alert] =
+  const [news, events, upcomingMeeting, previousMeeting, cafeOpen] =
     await Promise.allSettled([
       newsPromise,
       eventsPromise,
       upcomingMeetingPromise,
       previousMeetingPromise,
       cafeOpenPromise,
-      alertPromise,
     ]);
   if (news.status === "rejected") {
     throw error(500, "Failed to fetch news");
@@ -99,9 +93,6 @@ export const load: PageServerLoad = async ({ locals }) => {
   if (cafeOpen.status === "rejected") {
     throw error(500, "Failed to fetch cafe open");
   }
-  if (alert.status === "rejected") {
-    throw error(500, "Failed to fetch alerts");
-  }
   return {
     news: news.value,
     events: events.value,
@@ -110,6 +101,5 @@ export const load: PageServerLoad = async ({ locals }) => {
       previous: previousMeeting.value,
     },
     cafeOpen: cafeOpen.value,
-    alert: alert.value,
   };
 };

--- a/src/routes/(app)/+page.svelte
+++ b/src/routes/(app)/+page.svelte
@@ -6,8 +6,6 @@
   import Meetings from "./Meetings.svelte";
   import WellbeingCTA from "./WellbeingCTA.svelte";
 
-  import GlobalAlert from "$lib/components/GlobalAlert.svelte";
-  import { languageTag } from "$paraglide/runtime";
   import type { PageData } from "./$types";
   export let data: PageData;
 </script>
@@ -16,12 +14,6 @@
   <title>D-sektionen</title>
 </svelte:head>
 
-{#each data.alert as alert}
-  <GlobalAlert
-    message={languageTag() === "sv" ? alert.message : alert.messageEn}
-    severity={alert.severity}
-  />
-{/each}
 <div
   class="container mx-auto grid grid-cols-1 gap-8 p-4 md:grid-cols-2 lg:grid-cols-3"
 >

--- a/src/routes/(app)/admin/alerts/+page.server.ts
+++ b/src/routes/(app)/admin/alerts/+page.server.ts
@@ -2,6 +2,7 @@ import { fail } from "@sveltejs/kit";
 import type { PageServerLoad, Actions } from "./$types";
 import { z } from "zod";
 import { message, superValidate } from "sveltekit-superforms/server";
+import softDelete from "$lib/utils/softDelete";
 
 export const load: PageServerLoad = async ({ locals }) => {
   const { prisma } = locals;
@@ -51,14 +52,16 @@ export const actions = {
     const { prisma } = locals;
     const form = await superValidate(request, deleteAlertSchema);
     if (!form.valid) return fail(400, { form });
-    await prisma.alert.update({
-      where: { id: form.data.id },
-      data: {
-        removedAt: new Date(),
-      },
-    });
+    softDelete(() =>
+      prisma.alert.update({
+        where: { id: form.data.id },
+        data: {
+          removedAt: new Date(),
+        },
+      }),
+    );
     return message(form, {
-      message: "Global alert stängd",
+      message: "Global alert removed",
       type: "success",
     });
   },

--- a/src/routes/(app)/admin/alerts/+page.svelte
+++ b/src/routes/(app)/admin/alerts/+page.svelte
@@ -1,7 +1,12 @@
 <script lang="ts">
+  import { enhance } from "$app/forms";
+  import type { Alert } from "@prisma/client";
   import dayjs from "dayjs";
 
   export let data;
+
+  let removeModal: HTMLDialogElement | undefined = undefined;
+  let selectedAlert: Alert | undefined = undefined;
 </script>
 
 <form
@@ -35,29 +40,53 @@
   <thead>
     <tr>
       <th>Severity</th>
-      <th>Svenska</th>
-      <th>Engelska</th>
+      <th>Message</th>
       <th>Skapad</th>
       <th />
     </tr>
   </thead>
 
   <tbody>
-    {#each data.alert as { severity, message, messageEn, createdAt, id }}
+    {#each data.alert as alert}
       <tr>
-        <th class="capitalize">{severity}</th>
-        <td>{message}</td>
-        <td>{messageEn}</td>
-        <td>{dayjs(createdAt).format("YYYY-MM-DD HH:mm:ss")}</td>
+        <th class="capitalize">{alert.severity}</th>
+        <td>{alert.message}</td>
+        <td>{dayjs(alert.createdAt).format("YYYY-MM-DD HH:mm:ss")}</td>
         <td>
-          <form method="POST" action="?/delete">
-            <input class="hidden" type="text" name="id" value={id} />
-            <button class="btn btn-square" type="submit">
-              <span class="i-mdi-delete text-xl"></span>
-            </button>
-          </form>
+          <button
+            class="btn btn-square"
+            on:click={() => {
+              selectedAlert = alert;
+              removeModal?.showModal();
+            }}
+          >
+            <span class="i-mdi-delete text-xl" />
+          </button>
         </td>
       </tr>
     {/each}
   </tbody>
 </table>
+
+<dialog bind:this={removeModal} class="modal modal-bottom sm:modal-middle">
+  <div class="modal-box">
+    <h3 class="text-lg font-bold">Remove alert</h3>
+    <p class="py-4">Are you sure you want to remove this alert?</p>
+    <p class="text-xs text-base-content/60">{selectedAlert?.message}</p>
+    <div class="modal-action">
+      <form method="POST" action="?/delete" use:enhance>
+        <input type="hidden" name="id" value={selectedAlert?.id} />
+        <button
+          type="submit"
+          class="btn btn-error"
+          on:click={() => removeModal?.close()}
+        >
+          Remove
+        </button>
+      </form>
+    </div>
+  </div>
+  <form method="dialog" class="modal-backdrop">
+    <button class="cursor-auto" />
+  </form>
+</dialog>

--- a/src/routes/(app)/admin/alerts/+page.svelte
+++ b/src/routes/(app)/admin/alerts/+page.svelte
@@ -1,13 +1,7 @@
 <script lang="ts">
-  export let data;
+  import dayjs from "dayjs";
 
-  // YYYY-MM-DD HH:MM:SS
-  function formatTimestamp(timestamp: Date): string {
-    return timestamp
-      .toISOString()
-      .replace("T", " ")
-      .replace(/\.\d{3}Z$/, "");
-  }
+  export let data;
 </script>
 
 <form
@@ -38,23 +32,23 @@
 </form>
 <div class="divider">Aktiva alerts</div>
 <table class="table">
-  <!-- head -->
   <thead>
     <tr>
       <th>Severity</th>
       <th>Svenska</th>
       <th>Engelska</th>
       <th>Skapad</th>
-      <th>Ta bort</th>
+      <th />
     </tr>
   </thead>
+
   <tbody>
     {#each data.alert as { severity, message, messageEn, createdAt, id }}
       <tr>
         <th class="capitalize">{severity}</th>
         <td>{message}</td>
         <td>{messageEn}</td>
-        <td>{formatTimestamp(createdAt)}</td>
+        <td>{dayjs(createdAt).format("YYYY-MM-DD HH:mm:ss")}</td>
         <td>
           <form method="POST" action="?/delete">
             <input class="hidden" type="text" name="id" value={id} />


### PR DESCRIPTION
Closes #193, closes #237.

This PR fixes some small issues with global alerts:
- They are now visible on all pages, not just the landing page.
- The date formatting is now correctly localized by using the dayjs library (timezone was wrong).
- Users now get a "Are you sure?" dialog before deleting an alert.
- Users no longer get an `500 Internal Server Error` when deleting alerts.
- The message text in the table of alert now only shows the message in the current language.
As a sidenote, our current way of handling translations doesn't really support showing the Swedish and the English version on the same page. Instead, it would show the two languages correctly when viewing the page in Swedish, but in English it would simply show the English text in both columns.