### PR TITLE
Transfer build step from Jenkins to Github Actions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -5,7 +5,7 @@ name: Node.js CI
 
 on:
   push:
-    branches: ["main"]
+    branches: ["**"]
   pull_request:
     branches: ["main"]
 
@@ -28,3 +28,4 @@ jobs:
           cache: "pnpm"
       - run: pnpm i
       - run: pnpm run ci-check
+      - run: pnpm run build


### PR DESCRIPTION
Since Jenkins hasn't been working very well lately and everyone seems to agree that we want as much as possible in Github actions instead of Jenkins, I think it's about time we move what we can from Jenkins (which is everything at the moment).
Right now, the only differences between the check in Jenkins and the check in Github is that Jenkins also runs `pnpm run build`, and that Jenkins runs on every push to any branch, not just on main. 

I changed the Github Actions to also run `pnpm run build` and to run on push to any branch, but I'm not really sure if it actually needs to run on every push on every branch, main might be enough.

When this is merged I will turn off the Jenkins "Commitbuilder_new_web".