### PR TITLE
Start db before tests

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -5,7 +5,7 @@ name: Node.js CI
 
 on:
   push:
-    branches: ["**"]
+    branches: ["main"]
   pull_request:
     branches: ["main"]
 
@@ -27,5 +27,6 @@ jobs:
           node-version: lts/*
           cache: "pnpm"
       - run: pnpm i
+      - run: sh dev/setup_db.sh
       - run: pnpm run ci-check
       - run: pnpm run build


### PR DESCRIPTION
I looked into running the database with the tests in the ci. I found some stuff about [service containers](https://docs.github.com/en/actions/using-containerized-services/creating-postgresql-service-containers#running-jobs-directly-on-the-runner-machine) but didn't get it to work, and just running `sh dev/dev_setup.sh` seems to work. I have no clue if this is actually good practice, but I feel like it's good enough for now so our tests aren't constantly failing.