### PR TITLE
Improve stability of database setup script

### DIFF
--- a/dev/setup_db.sh
+++ b/dev/setup_db.sh
@@ -13,6 +13,8 @@ until docker exec dsek-db pg_isready
 do
     sleep 0.5;
 done
+echo "Database is ready! Loading data..."
+sleep 0.5; # Sometimes the database is not ready yet even though pg_isready returns true
 
 # Set `session_replication_role` to `'replica'`, this will temporarily disable
 # all foreign key checks. If you used the parameters for your postgresql docker


### PR DESCRIPTION
This pull request improves the stability of the database setup script by adding a delay before loading data to ensure that the database is fully ready. This prevents potential errors that may occur when the script tries to load data before the database is fully initialized.