### PR TITLE
Fix misc. access policy usage

### DIFF
--- a/src/lib/utils/apiNames.ts
+++ b/src/lib/utils/apiNames.ts
@@ -7,6 +7,7 @@ const crud = <prefix extends string>(base: prefix) =>
   }) as const;
 
 const apiNames = {
+  ALERT: "alert",
   NEWS: {
     ...crud("news:article"),
     MANAGE: "news:article:manage",
@@ -34,7 +35,7 @@ const apiNames = {
   ADMIN: {
     READ: "core:access:admin:read",
   },
-  ACCESS_POLICY: crud("core:access:api"),
+  ACCESS_POLICY: crud("core:access:policy"),
   EMAIL_ALIAS: crud("core:mail:alias"),
   LOGGED_IN: "_",
   FILES: {

--- a/src/lib/utils/apiNames.ts
+++ b/src/lib/utils/apiNames.ts
@@ -37,7 +37,6 @@ const apiNames = {
   },
   ACCESS_POLICY: crud("core:access:policy"),
   EMAIL_ALIAS: crud("core:mail:alias"),
-  LOGGED_IN: "_",
   FILES: {
     BUCKET: <bucketName extends string>(name: bucketName) =>
       crud(`fileHandler:${name.startsWith("dev-") ? name.substring(4) : name}`), // remove "dev-" prefix

--- a/src/routes/(app)/admin/alerts/+page.server.ts
+++ b/src/routes/(app)/admin/alerts/+page.server.ts
@@ -3,9 +3,12 @@ import type { PageServerLoad, Actions } from "./$types";
 import { z } from "zod";
 import { message, superValidate } from "sveltekit-superforms/server";
 import softDelete from "$lib/utils/softDelete";
+import { authorize } from "$lib/utils/authorization";
+import apiNames from "$lib/utils/apiNames";
 
 export const load: PageServerLoad = async ({ locals }) => {
   const { prisma } = locals;
+  authorize(apiNames.ALERT, locals.user);
   const alert = prisma.alert.findMany({
     where: {
       removedAt: null,
@@ -34,6 +37,7 @@ export type deleteAlertSchema = typeof deleteAlertSchema;
 export const actions = {
   create: async ({ request, locals }) => {
     const { prisma } = locals;
+    authorize(apiNames.ALERT, locals.user);
     const form = await superValidate(request, addAlertSchema);
     if (!form.valid) return fail(400, { form });
     await prisma.alert.create({
@@ -50,6 +54,7 @@ export const actions = {
   },
   delete: async ({ request, locals }) => {
     const { prisma } = locals;
+    authorize(apiNames.ALERT, locals.user);
     const form = await superValidate(request, deleteAlertSchema);
     if (!form.valid) return fail(400, { form });
     softDelete(() =>

--- a/src/routes/(app)/admin/doors/+page.svelte
+++ b/src/routes/(app)/admin/doors/+page.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+  import { page } from "$app/stores";
+  import apiNames from "$lib/utils/apiNames";
+  import { isAuthorized } from "$lib/utils/authorization";
   import type { PageData } from "./$types";
   export let data: PageData;
 </script>
@@ -18,9 +21,11 @@
           <td class="font-medium">
             {door.verboseName}
           </td>
-          <td class="text-right">
-            <a class="btn btn-xs px-8" href="doors/edit/{door.name}">Edit</a>
-          </td>
+          {#if isAuthorized(apiNames.DOOR.UPDATE, $page.data.user)}
+            <td class="text-right">
+              <a class="btn btn-xs px-8" href="doors/edit/{door.name}">Edit</a>
+            </td>
+          {/if}
         </tr>
       {/each}
     </tbody>

--- a/src/routes/(app)/admin/email-alias/+page.svelte
+++ b/src/routes/(app)/admin/email-alias/+page.svelte
@@ -3,6 +3,9 @@
   import Labeled from "$lib/components/Labeled.svelte";
   import PageHeader from "$lib/components/PageHeader.svelte";
   import { superForm } from "sveltekit-superforms/client";
+  import { isAuthorized } from "$lib/utils/authorization";
+  import apiNames from "$lib/utils/apiNames";
+  import { page } from "$app/stores";
 
   export let data;
 
@@ -64,154 +67,159 @@
 <PageHeader title="Mejlalias" />
 
 <div>
-  <div class="my-4 rounded-lg p-4">
-    <div class="border-b border-neutral p-4">
-      <h2 class="text-lg font-semibold">Lägg till mejlalias</h2>
-      <form
-        class="flex flex-row items-end gap-2"
-        use:createEmailPositionEnhance
-        action="?/createEmailPosition"
-        name="createEmailPosition"
-        method="POST"
-      >
-        <Input
-          name="localPartAlias"
-          id="localPartAlias"
-          label="Email"
-          required
-          bind:value={$createEmailPositionForm.localPartAlias}
-          {...$createEmailPositionConstraints.localPartAlias}
-          error={$createEmailPositionErrors.localPartAlias}
-        />
-        <Labeled label="Domain" error={$createEmailPositionErrors.domainAlias}>
-          <select
-            id="domainAlias"
-            name="domainAlias"
-            class="select select-bordered w-full max-w-xs"
-            bind:value={$createEmailPositionForm.domainAlias}
-            {...$createEmailPositionConstraints.domainAlias}
-            required
-          >
-            {#each data.domains as domain}
-              <option value={domain}>{domain}</option>
-            {/each}
-          </select>
-        </Labeled>
-        <Labeled label="Post">
-          <select
-            id="positionIdAlias"
-            name="positionIdAlias"
-            class="select select-bordered w-full max-w-xs"
-            bind:value={$createEmailPositionForm.positionIdAlias}
-            {...$createEmailPositionConstraints.positionIdAlias}
-            required
-          >
-            {#each data.positions as position (position.id)}
-              <option value={position.id}>{position.name}</option>
-            {/each}
-          </select>
-        </Labeled>
-        <button class="btn btn-primary" type="submit">Lägg till</button>
-      </form>
-    </div>
-
-    <div class="border-b border-neutral p-4">
-      <h2 class="text-lg font-semibold">Add Special Sender</h2>
-      <form
-        class="flex flex-row items-end gap-2"
-        action="?/createEmailSpecialSender"
-        name="createEmailSpecialSender"
-        method="POST"
-        use:createEmailSpecialSenderEnhance
-      >
-        <Input
-          name="localPartSender"
-          label="Email"
-          id="localPartSender"
-          required
-          bind:value={$createEmailSpecialSenderForm.localPartSender}
-          {...$createEmailSpecialSenderConstraints.localPartSender}
-          error={$createEmailSpecialSenderErrors.localPartSender}
-        />
-        <Labeled
-          label="Domain"
-          error={$createEmailSpecialSenderErrors.domainSender}
+  {#if isAuthorized(apiNames.EMAIL_ALIAS.CREATE, $page.data.user)}
+    <div class="my-4 rounded-lg p-4">
+      <div class="border-b border-neutral p-4">
+        <h2 class="text-lg font-semibold">Lägg till mejlalias</h2>
+        <form
+          class="flex flex-row items-end gap-2"
+          use:createEmailPositionEnhance
+          action="?/createEmailPosition"
+          name="createEmailPosition"
+          method="POST"
         >
-          <select
-            id="domainSender"
-            name="domainSender"
-            class="select select-bordered w-full max-w-xs"
-            bind:value={$createEmailSpecialSenderForm.domainSender}
-            {...$createEmailSpecialSenderConstraints.domainSender}
+          <Input
+            name="localPartAlias"
+            id="localPartAlias"
+            label="Email"
             required
+            bind:value={$createEmailPositionForm.localPartAlias}
+            {...$createEmailPositionConstraints.localPartAlias}
+            error={$createEmailPositionErrors.localPartAlias}
+          />
+          <Labeled
+            label="Domain"
+            error={$createEmailPositionErrors.domainAlias}
           >
-            {#each data.domains as domain}
-              <option value={domain}>{domain}</option>
-            {/each}
-          </select>
-        </Labeled>
-        <Input
-          name="usernameSender"
-          label="Student ID or Username"
-          required
-          id="usernameSender"
-          bind:value={$createEmailSpecialSenderForm.usernameSender}
-          {...$createEmailSpecialSenderConstraints.usernameSender}
-          error={$createEmailSpecialSenderErrors.usernameSender}
-        />
+            <select
+              id="domainAlias"
+              name="domainAlias"
+              class="select select-bordered w-full max-w-xs"
+              bind:value={$createEmailPositionForm.domainAlias}
+              {...$createEmailPositionConstraints.domainAlias}
+              required
+            >
+              {#each data.domains as domain}
+                <option value={domain}>{domain}</option>
+              {/each}
+            </select>
+          </Labeled>
+          <Labeled label="Post">
+            <select
+              id="positionIdAlias"
+              name="positionIdAlias"
+              class="select select-bordered w-full max-w-xs"
+              bind:value={$createEmailPositionForm.positionIdAlias}
+              {...$createEmailPositionConstraints.positionIdAlias}
+              required
+            >
+              {#each data.positions as position (position.id)}
+                <option value={position.id}>{position.name}</option>
+              {/each}
+            </select>
+          </Labeled>
+          <button class="btn btn-primary" type="submit">Lägg till</button>
+        </form>
+      </div>
 
-        <button class="btn btn-primary" type="submit">Lägg till</button>
-      </form>
-    </div>
-
-    <div class="p-4">
-      <h2 class="text-lg font-semibold">Add Special Receiver</h2>
-      <form
-        class="flex flex-row items-end gap-2"
-        action="?/createEmailSpecialReceiver"
-        name="createEmailSpecialReceiver"
-        method="POST"
-        use:createEmailSpecialReceiverEnhance
-      >
-        <Input
-          name="localPartReceiver"
-          label="Email"
-          required
-          id="localPartReceiver"
-          bind:value={$createEmailSpecialReceiverForm.localPartReceiver}
-          {...$createEmailSpecialReceiverConstraints.localPartReceiver}
-          error={$createEmailSpecialReceiverErrors.localPartReceiver}
-        />
-        <Labeled
-          label="Domain"
-          error={$createEmailSpecialReceiverErrors.domainReceiver}
+      <div class="border-b border-neutral p-4">
+        <h2 class="text-lg font-semibold">Add Special Sender</h2>
+        <form
+          class="flex flex-row items-end gap-2"
+          action="?/createEmailSpecialSender"
+          name="createEmailSpecialSender"
+          method="POST"
+          use:createEmailSpecialSenderEnhance
         >
-          <select
-            id="domainReceiver"
-            name="domainReceiver"
-            class="select select-bordered w-full max-w-xs"
-            bind:value={$createEmailSpecialReceiverForm.domainReceiver}
-            {...$createEmailSpecialReceiverConstraints.domainReceiver}
+          <Input
+            name="localPartSender"
+            label="Email"
+            id="localPartSender"
             required
+            bind:value={$createEmailSpecialSenderForm.localPartSender}
+            {...$createEmailSpecialSenderConstraints.localPartSender}
+            error={$createEmailSpecialSenderErrors.localPartSender}
+          />
+          <Labeled
+            label="Domain"
+            error={$createEmailSpecialSenderErrors.domainSender}
           >
-            {#each data.domains as domain}
-              <option value={domain}>{domain}</option>
-            {/each}
-          </select>
-        </Labeled>
-        <Input
-          name="targetEmailReceiver"
-          label="Target Email"
-          required
-          id="targetEmailReceiver"
-          bind:value={$createEmailSpecialReceiverForm.targetEmailReceiver}
-          error={$createEmailSpecialReceiverErrors.targetEmailReceiver}
-          {...$createEmailSpecialReceiverConstraints.targetEmailReceiver}
-        />
-        <button class="btn btn-primary" type="submit">Lägg till</button>
-      </form>
+            <select
+              id="domainSender"
+              name="domainSender"
+              class="select select-bordered w-full max-w-xs"
+              bind:value={$createEmailSpecialSenderForm.domainSender}
+              {...$createEmailSpecialSenderConstraints.domainSender}
+              required
+            >
+              {#each data.domains as domain}
+                <option value={domain}>{domain}</option>
+              {/each}
+            </select>
+          </Labeled>
+          <Input
+            name="usernameSender"
+            label="Student ID or Username"
+            required
+            id="usernameSender"
+            bind:value={$createEmailSpecialSenderForm.usernameSender}
+            {...$createEmailSpecialSenderConstraints.usernameSender}
+            error={$createEmailSpecialSenderErrors.usernameSender}
+          />
+
+          <button class="btn btn-primary" type="submit">Lägg till</button>
+        </form>
+      </div>
+
+      <div class="p-4">
+        <h2 class="text-lg font-semibold">Add Special Receiver</h2>
+        <form
+          class="flex flex-row items-end gap-2"
+          action="?/createEmailSpecialReceiver"
+          name="createEmailSpecialReceiver"
+          method="POST"
+          use:createEmailSpecialReceiverEnhance
+        >
+          <Input
+            name="localPartReceiver"
+            label="Email"
+            required
+            id="localPartReceiver"
+            bind:value={$createEmailSpecialReceiverForm.localPartReceiver}
+            {...$createEmailSpecialReceiverConstraints.localPartReceiver}
+            error={$createEmailSpecialReceiverErrors.localPartReceiver}
+          />
+          <Labeled
+            label="Domain"
+            error={$createEmailSpecialReceiverErrors.domainReceiver}
+          >
+            <select
+              id="domainReceiver"
+              name="domainReceiver"
+              class="select select-bordered w-full max-w-xs"
+              bind:value={$createEmailSpecialReceiverForm.domainReceiver}
+              {...$createEmailSpecialReceiverConstraints.domainReceiver}
+              required
+            >
+              {#each data.domains as domain}
+                <option value={domain}>{domain}</option>
+              {/each}
+            </select>
+          </Labeled>
+          <Input
+            name="targetEmailReceiver"
+            label="Target Email"
+            required
+            id="targetEmailReceiver"
+            bind:value={$createEmailSpecialReceiverForm.targetEmailReceiver}
+            error={$createEmailSpecialReceiverErrors.targetEmailReceiver}
+            {...$createEmailSpecialReceiverConstraints.targetEmailReceiver}
+          />
+          <button class="btn btn-primary" type="submit">Lägg till</button>
+        </form>
+      </div>
     </div>
-  </div>
+  {/if}
 
   <div class="overflow-x-auto">
     <h1 class="my-4 text-2xl font-bold">Email-alias</h1>
@@ -236,11 +244,13 @@
                 <span class="font-mono">{positionId}</span>
               {/each}
             </td>
-            <td class="text-right">
-              <a class="btn btn-xs px-8" href="email-alias/{emailAlias[0]}"
-                >Ändra</a
-              ></td
-            >
+            {#if isAuthorized(apiNames.EMAIL_ALIAS.UPDATE, $page.data.user)}
+              <td class="text-right">
+                <a class="btn btn-xs px-8" href="email-alias/{emailAlias[0]}"
+                  >Ändra</a
+                ></td
+              >
+            {/if}
           </tr>
         {/each}
       </tbody>
@@ -270,11 +280,12 @@
                 <span class="font-mono">{studentId}</span>
               {/each}
             </td>
-
-            <td class="text-right">
-              <a class="btn btn-xs px-8" href="email-alias/{email}">Ändra</a
-              ></td
-            >
+            {#if isAuthorized(apiNames.EMAIL_ALIAS.UPDATE, $page.data.user)}
+              <td class="text-right">
+                <a class="btn btn-xs px-8" href="email-alias/{email}">Ändra</a
+                ></td
+              >
+            {/if}
           </tr>
         {/each}
       </tbody>
@@ -304,10 +315,12 @@
                 <span class="font-mono">{targetEmail}</span>
               {/each}
             </td>
-            <td class="text-right">
-              <a class="btn btn-xs px-8" href="email-alias/{email}">Ändra</a
-              ></td
-            >
+            {#if isAuthorized(apiNames.EMAIL_ALIAS.UPDATE, $page.data.user)}
+              <td class="text-right">
+                <a class="btn btn-xs px-8" href="email-alias/{email}">Ändra</a
+                ></td
+              >
+            {/if}
           </tr>
         {/each}
       </tbody>

--- a/src/routes/(app)/notifications/+page.server.ts
+++ b/src/routes/(app)/notifications/+page.server.ts
@@ -1,7 +1,5 @@
-import apiNames from "$lib/utils/apiNames";
-import { authorize } from "$lib/utils/authorization";
 import { notificationSchema } from "$lib/zod/schemas";
-import { fail, redirect } from "@sveltejs/kit";
+import { error, fail, redirect } from "@sveltejs/kit";
 import { message, superValidate } from "sveltekit-superforms/server";
 import type { Actions } from "./$types";
 
@@ -13,7 +11,9 @@ export const actions: Actions = {
   // Mark all unread notifications as read
   readNotifications: async ({ locals, request }) => {
     const { user, prisma } = locals;
-    authorize(apiNames.LOGGED_IN, user);
+    if (!user.memberId) {
+      error(403, "Not logged in");
+    }
     const form = await superValidate(request, notificationSchema);
     if (!form.valid) return fail(400, { form });
     const idFilter =
@@ -42,7 +42,9 @@ export const actions: Actions = {
   // Delete single or multiple notifications on database
   deleteNotification: async ({ locals, request }) => {
     const { user, prisma } = locals;
-    authorize(apiNames.LOGGED_IN, user);
+    if (!user.memberId) {
+      error(403, "Not logged in");
+    }
     const form = await superValidate(request, notificationSchema);
     if (!form.valid) return fail(400, { form });
     // If multiple ids and not a single id have been provided, delete many, otherwise,

--- a/src/routes/routes.ts
+++ b/src/routes/routes.ts
@@ -85,7 +85,7 @@ export const routes = [
     title: "Admin",
     path: null,
     icon: "i-mdi-security",
-    accessRequired: apiNames.ACCESS_POLICY.READ,
+    accessRequired: apiNames.ADMIN.READ,
     children: [
       {
         title: "Access",
@@ -109,7 +109,7 @@ export const routes = [
         title: "Alerts",
         path: "/admin/alerts",
         icon: "i-mdi-alert-circle",
-        accessRequired: apiNames.DOOR.READ, //temporary, make right api accsess
+        accessRequired: apiNames.ALERT,
       },
     ],
   },


### PR DESCRIPTION
Update policies for the admin page so everyone doesn't have read access, and so that the admin button in the navbar isn't visible to everyone.
I also added access checks to the email-alias page so you can't see the form if you can't create/edit aliases.

I also found that I couldn't delete/read my notifications, this was because it used LOGGED_IN (="_") from apiNames, which is used in the db to say that all logged in users has some access policy, but it's not an access policy itself so `authorize(apiNames.LOGGED_IN, user)` would always throw an error.