### PR TITLE
Fix relative path in SearchBar goto

### DIFF
--- a/src/lib/components/SearchBar.svelte
+++ b/src/lib/components/SearchBar.svelte
@@ -15,7 +15,9 @@
       if (search !== undefined) urlParams.set("search", search);
       else urlParams.delete("search");
       urlParams.delete("page");
-      await goto(`?${urlParams.toString()}`, { replaceState: true });
+      await goto(`${$page.url.pathname}?${urlParams.toString()}`, {
+        replaceState: true,
+      });
       await tick();
       setTimeout(() => {
         inputField.focus();


### PR DESCRIPTION
### Fixed

SearchBar falsely redirects to /. Fix to redirect to current page and update the URLSearchParams

### Steps to reproduce Bug

1. Go to [https://new.dsek.se/en/news](https://new.dsek.se/en/news)
2. Type something in the search bar
3. Magically get transported to / or /home