### PR TITLE
Fixed dark mode flash when reloading

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -12,6 +12,13 @@
       name="description"
       content="D-sektionen inom TLTH är en ideell organisation för studenter och alumner vid programmen Datateknik och InfoCom."
     />
+    <script>
+      localStorage.theme === "dark" ||
+      (!("theme" in localStorage) &&
+        window.matchMedia("(prefers-color-schema: dark)").matches)
+        ? document.documentElement.setAttribute("data-theme", "dark")
+        : document.documentElement.setAttribute("data-theme", "light");
+    </script>
     %sveltekit.head%
   </head>
   <body class="flex min-h-screen flex-col" data-sveltekit-preload-data="hover">


### PR DESCRIPTION
Adds data-theme attribute from localstorage before rest is loaded, should also fix :dark.

Fixes and closes #349