### PR TITLE
Change light mode primary to one with correct chroma

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -20,7 +20,7 @@ export default {
     themes: [
       {
         light: {
-          primary: "#d93464",
+          primary: "#cc5e80",
           secondary: "#9966CC",
           accent: "#1dcdbc",
           neutral: "#2b3440",


### PR DESCRIPTION
In this PR I change the light mode primary color to one that is one of the correct chroma.

I did this by plugging `#F280A1` into https://oklch.com/ and then reducing the lightness until we reached WCAG AAA for all text elements on the landing page. 