### PR TITLE
Hide "staben" by denying reads of positions and mandates of them

### DIFF
--- a/src/database/prisma/schema.prisma
+++ b/src/database/prisma/schema.prisma
@@ -473,6 +473,7 @@ model Keycloak {
 /// @@allow('read', has(auth().policies, 'core:mandate:read'))
 /// @@allow('update', has(auth().policies, 'core:mandate:update'))
 /// @@allow('delete', has(auth().policies, 'core:mandate:delete'))
+/// @@deny('read', positionId == 'dsek.noll.stab.mdlm' || positionId == 'dsek.noll.stab.oph')
 /// This model or at least one of its fields has comments in the database, and requires an additional setup for migrations: Read more: https://pris.ly/d/database-commentsmodel Mandates{
 model Mandate {
     id String @id() @default(dbgenerated("gen_random_uuid()")) @db.Uuid()
@@ -650,6 +651,7 @@ model Ping {
 /// @@allow('update', has(auth().policies, 'core:position:update'))
 /// @@allow('delete', has(auth().policies, 'core:position:delete'))
 /// @@deny('read', active == false && !has(auth().policies, 'core:position:inactive:read'))
+/// @@deny('read', id == 'dsek.noll.stab.mdlm' || id == 'dsek.noll.stab.oph')
 /// This model or at least one of its fields has comments in the database, and requires an additional setup for migrations: Read more: https://pris.ly/d/database-commentsmodel Positions{
 model Position {
     id String @id() @db.VarChar(255)

--- a/src/database/prisma/schema.prisma
+++ b/src/database/prisma/schema.prisma
@@ -57,7 +57,7 @@ model AdminSetting {
     key String @id() @db.VarChar(255)
     value String? @db.VarChar(255)
     createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz(6)
-    updatedAt DateTime @default(now()) @map("updated_at") @db.Timestamptz(6)
+    updatedAt DateTime @default(now()) @updatedAt() @map("updated_at") @db.Timestamptz(6)
 
     @@map("admin_settings")
 }
@@ -473,7 +473,7 @@ model Keycloak {
 /// @@allow('read', has(auth().policies, 'core:mandate:read'))
 /// @@allow('update', has(auth().policies, 'core:mandate:update'))
 /// @@allow('delete', has(auth().policies, 'core:mandate:delete'))
-/// @@deny('read', positionId == 'dsek.noll.stab.mdlm' || positionId == 'dsek.noll.stab.oph')
+/// @@deny('read', positionId == 'dsek.noll.stab.mdlm' || positionId == 'dsek.noll.stab.oph' && !has(auth().policies, 'member:see_staben'))
 /// This model or at least one of its fields has comments in the database, and requires an additional setup for migrations: Read more: https://pris.ly/d/database-commentsmodel Mandates{
 model Mandate {
     id String @id() @default(dbgenerated("gen_random_uuid()")) @db.Uuid()
@@ -519,6 +519,7 @@ model Meeting {
 /// @@allow('update', auth().studentId == studentId)
 /// @@allow('update', has(auth().policies, 'core:member:update'))
 /// @@allow('delete', has(auth().policies, 'core:member:delete'))
+/// @@deny('read', mandates?[startDate < now() && now() < endDate && (positionId == 'dsek.noll.stab.mdlm' || positionId == 'dsek.noll.stab.oph')] && !has(auth().policies, 'member:see_staben') && auth().memberId != id)
 /// This model or at least one of its fields has comments in the database, and requires an additional setup for migrations: Read more: https://pris.ly/d/database-commentsmodel Members{
 model Member {
     id String @id() @default(dbgenerated("gen_random_uuid()")) @db.Uuid()
@@ -651,7 +652,7 @@ model Ping {
 /// @@allow('update', has(auth().policies, 'core:position:update'))
 /// @@allow('delete', has(auth().policies, 'core:position:delete'))
 /// @@deny('read', active == false && !has(auth().policies, 'core:position:inactive:read'))
-/// @@deny('read', id == 'dsek.noll.stab.mdlm' || id == 'dsek.noll.stab.oph')
+/// @@deny('read', id == 'dsek.noll.stab.mdlm' || id == 'dsek.noll.stab.oph' && !has(auth().policies, 'member:see_staben'))
 /// This model or at least one of its fields has comments in the database, and requires an additional setup for migrations: Read more: https://pris.ly/d/database-commentsmodel Positions{
 model Position {
     id String @id() @db.VarChar(255)

--- a/src/database/prisma/schema.prisma
+++ b/src/database/prisma/schema.prisma
@@ -165,10 +165,12 @@ model Article {
 
 /// @@allow('create', has(auth().policies, 'news:article:create'))
 /// @@allow('read', has(auth().policies, 'news:article:read'))
+/// @@deny('read', type != 'Custom' && (startsWith(mandate.positionId, 'dsek.noll.stab.') || member.mandates?[startDate < now() && now() < endDate && startsWith(positionId, 'dsek.noll.stab.')]) && !has(auth().policies, 'member:see_staben') && auth().memberId != memberId)
 /// This table contains check constraints and requires additional setup for migrations. Visit https://pris.ly/d/check-constraints for more info.
 /// This model or at least one of its fields has comments in the database, and requires an additional setup for migrations: Read more: https://pris.ly/d/database-comments
 model Author {
     id String @id() @default(dbgenerated("gen_random_uuid()")) @db.Uuid()
+    /// @deny('read', member.mandates?[startDate < now() && now() < endDate && startsWith(positionId, 'dsek.noll.stab.')] && !has(auth().policies, 'member:see_staben') && auth().memberId != memberId)
     memberId String @map("member_id") @db.Uuid()
     mandateId String? @map("mandate_id") @db.Uuid()
     customId String? @map("custom_id") @db.Uuid()
@@ -519,7 +521,6 @@ model Meeting {
 /// @@allow('update', auth().studentId == studentId)
 /// @@allow('update', has(auth().policies, 'core:member:update'))
 /// @@allow('delete', has(auth().policies, 'core:member:delete'))
-/// @@deny('read', mandates?[startDate < now() && now() < endDate && (positionId == 'dsek.noll.stab.mdlm' || positionId == 'dsek.noll.stab.oph')] && !has(auth().policies, 'member:see_staben') && auth().memberId != id)
 /// This model or at least one of its fields has comments in the database, and requires an additional setup for migrations: Read more: https://pris.ly/d/database-commentsmodel Members{
 model Member {
     id String @id() @default(dbgenerated("gen_random_uuid()")) @db.Uuid()

--- a/src/database/prisma/schema.prisma
+++ b/src/database/prisma/schema.prisma
@@ -57,7 +57,7 @@ model AdminSetting {
     key String @id() @db.VarChar(255)
     value String? @db.VarChar(255)
     createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz(6)
-    updatedAt DateTime @default(now()) @updatedAt() @map("updated_at") @db.Timestamptz(6)
+    updatedAt DateTime @updatedAt() @map("updated_at") @db.Timestamptz(6)
 
     @@map("admin_settings")
 }
@@ -874,7 +874,7 @@ model Shoppable {
     availableFrom DateTime @map("available_from") @db.Timestamptz(6) @default(now())
     availableTo DateTime? @map("available_to") @db.Timestamptz(6)
     createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz(6) @ignore()
-    updatedAt DateTime @default(now()) @map("updated_at") @db.Timestamptz(6) @updatedAt()
+    updatedAt DateTime @map("updated_at") @db.Timestamptz(6) @updatedAt()
     removedAt DateTime? @map("removed_at") @db.Timestamptz(6)
     ticket Ticket?
     consumables Consumable[]

--- a/src/database/schema.zmodel
+++ b/src/database/schema.zmodel
@@ -478,6 +478,7 @@ model Mandate {
   @@allow("read", has(auth().policies, "core:mandate:read"))
   @@allow("update", has(auth().policies, "core:mandate:update"))
   @@allow("delete", has(auth().policies, "core:mandate:delete"))
+  @@deny("read", positionId == "dsek.noll.stab.mdlm" || positionId == "dsek.noll.stab.oph")
   @@map("mandates")
 }
 
@@ -656,6 +657,7 @@ model Position {
   @@allow("update", has(auth().policies, "core:position:update"))
   @@allow("delete", has(auth().policies, "core:position:delete"))
   @@deny("read", active == false && !has(auth().policies, "core:position:inactive:read"))
+  @@deny("read", id == "dsek.noll.stab.mdlm" || id == "dsek.noll.stab.oph")
   @@map("positions")
 }
 

--- a/src/database/schema.zmodel
+++ b/src/database/schema.zmodel
@@ -23,6 +23,7 @@ model User {
   memberId     String
   policies     String[]
   externalCode String? // for non-authenticated users, like purchasing tickets
+  isNollning Boolean? @default(false) // Only way to get the context
   @@ignore
 }
 
@@ -478,7 +479,7 @@ model Mandate {
   @@allow("read", has(auth().policies, "core:mandate:read"))
   @@allow("update", has(auth().policies, "core:mandate:update"))
   @@allow("delete", has(auth().policies, "core:mandate:delete"))
-  @@deny("read", positionId == "dsek.noll.stab.mdlm" || positionId == "dsek.noll.stab.oph")
+  @@deny("read", (positionId == "dsek.noll.stab.mdlm" || positionId == "dsek.noll.stab.oph") && auth().isNollning)
   @@map("mandates")
 }
 
@@ -657,7 +658,7 @@ model Position {
   @@allow("update", has(auth().policies, "core:position:update"))
   @@allow("delete", has(auth().policies, "core:position:delete"))
   @@deny("read", active == false && !has(auth().policies, "core:position:inactive:read"))
-  @@deny("read", id == "dsek.noll.stab.mdlm" || id == "dsek.noll.stab.oph")
+  @@deny("read", (id == "dsek.noll.stab.mdlm" || id == "dsek.noll.stab.oph") && auth().isNollning)
   @@map("positions")
 }
 

--- a/src/database/schema.zmodel
+++ b/src/database/schema.zmodel
@@ -30,7 +30,7 @@ model AdminSetting {
   key       String   @id @db.VarChar(255)
   value     String?  @db.VarChar(255)
   createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz(6)
-  updatedAt DateTime @default(now()) @updatedAt @map("updated_at") @db.Timestamptz(6)
+  updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamptz(6)
 
   @@allow("create", has(auth().policies, "admin:settings:create"))
   @@allow("read", has(auth().policies, "admin:settings:read"))
@@ -885,7 +885,7 @@ model Shoppable {
 
 
   createdAt     DateTime                @default(now()) @map("created_at") @db.Timestamptz(6) @ignore()
-  updatedAt     DateTime                @default(now()) @map("updated_at") @db.Timestamptz(6) @updatedAt()
+  updatedAt     DateTime                @map("updated_at") @db.Timestamptz(6) @updatedAt()
   removedAt     DateTime?               @map("removed_at") @db.Timestamptz(6)
 
   ticket        Ticket?

--- a/src/database/schema.zmodel
+++ b/src/database/schema.zmodel
@@ -144,7 +144,7 @@ model Article {
 /// This model or at least one of its fields has comments in the database, and requires an additional setup for migrations: Read more: https://pris.ly/d/database-comments
 model Author {
   id            String         @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
-  memberId      String         @map("member_id") @db.Uuid
+  memberId      String         @map("member_id") @db.Uuid @deny("read", member.mandates?[startDate < now() && now() < endDate && (startsWith(positionId, "dsek.noll.stab."))] && !has(auth().policies, "member:see_staben") && auth().memberId != memberId)
   mandateId     String?        @map("mandate_id") @db.Uuid
   customId      String?        @map("custom_id") @db.Uuid
   createdAt     DateTime       @default(now()) @map("created_at") @db.Timestamptz(6)
@@ -161,6 +161,13 @@ model Author {
   @@allow("read", has(auth().policies, "news:article:read"))
   @@unique([memberId, mandateId, customId], map: "authors_member_id_mandate_id_custom_id_unique")
   @@map("authors")
+
+  // Hide author if the member behind it is currently stab, or if it was posted as a "stab" mandate, AND user does not "see staben"
+  // There is one exception: If the author is of type "Custom Author" then it is fine to show, as the person behind it is not shown
+  @@deny("read", type != "Custom" && (
+                  startsWith(mandate.positionId, "dsek.noll.stab.") 
+                  || member.mandates?[startDate < now() && now() < endDate && (startsWith(positionId, "dsek.noll.stab."))]
+                  ) && !has(auth().policies, "member:see_staben") && auth().memberId != memberId)
 }
 
 model BookableCategory {
@@ -551,8 +558,6 @@ model Member {
   @@allow('update', auth().studentId == studentId)
   @@allow('update', has(auth().policies, "core:member:update"))
   @@allow('delete', has(auth().policies, "core:member:delete"))
-  // Hide member accounts for staben during the nollning
-  @@deny("read", (mandates?[startDate < now() && now() < endDate && (positionId == "dsek.noll.stab.mdlm" || positionId == "dsek.noll.stab.oph")]) && !has(auth().policies, "member:see_staben") && auth().memberId != id)
   @@map("members")
 }
 

--- a/src/database/schema.zmodel
+++ b/src/database/schema.zmodel
@@ -23,7 +23,6 @@ model User {
   memberId     String
   policies     String[]
   externalCode String? // for non-authenticated users, like purchasing tickets
-  isNollning Boolean? @default(false) // Only way to get the context
   @@ignore
 }
 
@@ -31,7 +30,7 @@ model AdminSetting {
   key       String   @id @db.VarChar(255)
   value     String?  @db.VarChar(255)
   createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz(6)
-  updatedAt DateTime @default(now()) @map("updated_at") @db.Timestamptz(6)
+  updatedAt DateTime @default(now()) @updatedAt @map("updated_at") @db.Timestamptz(6)
 
   @@allow("create", has(auth().policies, "admin:settings:create"))
   @@allow("read", has(auth().policies, "admin:settings:read"))
@@ -479,7 +478,8 @@ model Mandate {
   @@allow("read", has(auth().policies, "core:mandate:read"))
   @@allow("update", has(auth().policies, "core:mandate:update"))
   @@allow("delete", has(auth().policies, "core:mandate:delete"))
-  @@deny("read", (positionId == "dsek.noll.stab.mdlm" || positionId == "dsek.noll.stab.oph") && auth().isNollning)
+  // Hide all stab mandates during the nollning
+  @@deny("read", (positionId == "dsek.noll.stab.mdlm" || positionId == "dsek.noll.stab.oph") && !has(auth().policies, "member:see_staben"))
   @@map("mandates")
 }
 
@@ -551,6 +551,8 @@ model Member {
   @@allow('update', auth().studentId == studentId)
   @@allow('update', has(auth().policies, "core:member:update"))
   @@allow('delete', has(auth().policies, "core:member:delete"))
+  // Hide member accounts for staben during the nollning
+  @@deny("read", (mandates?[startDate < now() && now() < endDate && (positionId == "dsek.noll.stab.mdlm" || positionId == "dsek.noll.stab.oph")]) && !has(auth().policies, "member:see_staben") && auth().memberId != id)
   @@map("members")
 }
 
@@ -658,7 +660,8 @@ model Position {
   @@allow("update", has(auth().policies, "core:position:update"))
   @@allow("delete", has(auth().policies, "core:position:delete"))
   @@deny("read", active == false && !has(auth().policies, "core:position:inactive:read"))
-  @@deny("read", (id == "dsek.noll.stab.mdlm" || id == "dsek.noll.stab.oph") && auth().isNollning)
+  // Hide stab position during the nollning
+  @@deny("read", (id == "dsek.noll.stab.mdlm" || id == "dsek.noll.stab.oph") && !has(auth().policies, "member:see_staben"))
   @@map("positions")
 }
 

--- a/src/hooks.server.helpers.ts
+++ b/src/hooks.server.helpers.ts
@@ -19,7 +19,7 @@ export const getAccessPolicies = async (
   if (!!studentId && dev) {
     return getAllAccessPolicies(prisma);
   }
-  const isNollning = await isNollningPeriod(prisma);
+  const isNollning = await isNollningPeriod();
   return prisma.accessPolicy
     .findMany({
       where: {

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -10,7 +10,7 @@ import { SvelteKitAuth } from "@auth/sveltekit";
 import { PrismaClient } from "@prisma/client";
 import { error, type Handle } from "@sveltejs/kit";
 import { sequence } from "@sveltejs/kit/hooks";
-import { enhance, type AuthUser } from "@zenstackhq/runtime";
+import { enhance } from "@zenstackhq/runtime";
 import RPCApiHandler from "@zenstackhq/server/api/rpc";
 import zenstack from "@zenstackhq/server/sveltekit";
 import { randomBytes } from "crypto";
@@ -146,7 +146,7 @@ const databaseHandle: Handle = async ({ event, resolve }) => {
       redirect(302, "/onboarding");
     }
 
-    const user: AuthUser = {
+    const user = {
       studentId: session.user.student_id,
       memberId: member!.id,
       policies: await getAccessPolicies(

--- a/src/lib/components/AuthorSignature.svelte
+++ b/src/lib/components/AuthorSignature.svelte
@@ -2,7 +2,10 @@
   import MemberImage from "$lib/components/socials/MemberImage.svelte";
   import { getFullName } from "$lib/utils/client/member";
   import type { Author, CustomAuthor, Member, Position } from "@prisma/client";
+  import { twMerge } from "tailwind-merge";
 
+  let clazz = "";
+  export { clazz as class };
   export let member: Pick<
     Member,
     "firstName" | "lastName" | "nickname" | "studentId" | "picturePath"
@@ -13,13 +16,13 @@
   export let type: Author["type"] = "Member";
   export let size: "sm" | "md" | "lg" | "xl" = "lg";
   export let links = true;
-  const sizeToWidth = {
+  const sizeToWidth: Record<typeof size, string> = {
     sm: "w-4",
     md: "w-8",
     lg: "w-12",
     xl: "w-16",
   };
-  const sizeToGap = {
+  const sizeToGap: Record<typeof size, string> = {
     sm: "gap-2",
     md: "gap-2",
     lg: "gap-3",
@@ -27,7 +30,9 @@
   };
 </script>
 
-<div class="flex flex-row items-center {sizeToGap[size]}">
+<div
+  class={twMerge(`${sizeToGap[size]} flex grow flex-row items-center`, clazz)}
+>
   <div class="avatar">
     <div class="{sizeToWidth[size]} m-2 rounded-full">
       {#if type == "Custom" && customAuthor != null}
@@ -59,24 +64,25 @@
       {/if}
     </div>
   </div>
-  <div>
+  <div class="flex grow flex-col items-stretch">
     {#if type == "Custom" && customAuthor != null}
-      <h3 class="text-{size} font-semibold">
+      <h3 class="text-{size}">
         {customAuthor.name}
       </h3>
     {:else}
       <a
         href="/members/{member.studentId}"
         tabindex={links ? 0 : -1}
-        class="transition-opacity hover:opacity-80 focus:opacity-80 {links
-          ? ''
-          : 'pointer-events-none'}"
+        class="font-semibold transition-opacity hover:opacity-80 focus:opacity-80"
+        class:pointer-events-none={!links}
       >
         <h3 class="text-{size} font-semibold">
           {getFullName(member)}
         </h3>
       </a>
-      {#if position}
+    {/if}
+    <div class="flex justify-between">
+      {#if (type !== "Custom" || customAuthor == null) && position}
         <h3 class="text-sm font-thin">
           <a
             href="/positions/{position.id}"
@@ -88,7 +94,11 @@
             {position.name}
           </a>
         </h3>
+      {:else}
+        <div />
+        <!-- for positioning the slot correctly -->
       {/if}
-    {/if}
+      <slot name="end" />
+    </div>
   </div>
 </div>

--- a/src/lib/components/LoadingButton.svelte
+++ b/src/lib/components/LoadingButton.svelte
@@ -1,11 +1,13 @@
 <script lang="ts">
-  export let onClick: () => Promise<unknown>;
-  let isLoading = false;
+  export let onClick: (() => Promise<unknown> | void) | "default";
+  export let isLoading = false;
 </script>
 
 <button
+  disabled={isLoading}
   {...$$props}
   on:click={async () => {
+    if (onClick === "default") return;
     isLoading = true;
     await onClick();
     isLoading = false;

--- a/src/lib/server/shop/mock.ts
+++ b/src/lib/server/shop/mock.ts
@@ -12,10 +12,10 @@ export const MOCK_EVENT_1 = {
   endDatetime: new Date(Date.now() + 1000 * 60 * 60 * 24 * 8),
   tags: [
     {
-      name: "tag1",
+      name: "MOCKED_tag1",
     },
     {
-      name: "tag2",
+      name: "MOCKED_tag2",
     },
   ],
 };
@@ -271,6 +271,13 @@ export const removeAllTestData = async (
     where: {
       studentId: {
         startsWith: "test" + suitePrefix,
+      },
+    },
+  });
+  await prisma.tag.deleteMany({
+    where: {
+      name: {
+        startsWith: "MOCKED_",
       },
     },
   });

--- a/src/lib/utils/adminSettings/nollning.ts
+++ b/src/lib/utils/adminSettings/nollning.ts
@@ -45,19 +45,27 @@ export const updateNollningPeriod = async (
   end: Date,
 ) => {
   const res = await prisma.$transaction(async (tx) => {
-    await tx.adminSetting.update({
+    await tx.adminSetting.upsert({
       where: {
         key: NOLLNING_START_KEY,
       },
-      data: {
+      update: {
+        value: start.toISOString(),
+      },
+      create: {
+        key: NOLLNING_START_KEY,
         value: start.toISOString(),
       },
     });
-    await tx.adminSetting.update({
+    await tx.adminSetting.upsert({
       where: {
         key: NOLLNING_END_KEY,
       },
-      data: {
+      update: {
+        value: end.toISOString(),
+      },
+      create: {
+        key: NOLLNING_END_KEY,
         value: end.toISOString(),
       },
     });

--- a/src/lib/utils/adminSettings/nollning.ts
+++ b/src/lib/utils/adminSettings/nollning.ts
@@ -27,7 +27,7 @@ export const isNollningPeriod = async (prisma: PrismaClient) => {
     },
   });
   const startStr = rows.find((row) => row.key === NOLLNING_START_KEY)?.value;
-  const endStr = rows.find((row) => row.key === NOLLNING_START_KEY)?.value;
+  const endStr = rows.find((row) => row.key === NOLLNING_END_KEY)?.value;
   if (!startStr || !endStr) return false;
   const start = new Date(startStr);
   const end = new Date(endStr);

--- a/src/lib/utils/apiNames.ts
+++ b/src/lib/utils/apiNames.ts
@@ -34,6 +34,7 @@ const apiNames = {
   },
   ADMIN: {
     READ: "core:access:admin:read",
+    SETTINGS: crud("admin:settings"),
   },
   ACCESS_POLICY: crud("core:access:policy"),
   EMAIL_ALIAS: crud("core:mail:alias"),
@@ -48,6 +49,7 @@ const apiNames = {
   },
   MEMBER: {
     ...crud("core:member"),
+    SEE_STABEN: "member:see_staben",
     PING: "core:member:ping",
   },
   GOVERNING_DOCUMENT: {

--- a/src/routes/(app)/admin/settings/+page.server.ts
+++ b/src/routes/(app)/admin/settings/+page.server.ts
@@ -8,8 +8,9 @@ import { authorize } from "$lib/utils/authorization.js";
 import { fail } from "@sveltejs/kit";
 import { message, superValidate } from "sveltekit-superforms/client";
 import { z } from "zod";
+import type { PageServerLoad } from "./$types.js";
 
-export const load = async ({ locals }) => {
+export const load: PageServerLoad = async ({ locals }) => {
   const { prisma, user } = locals;
   authorize(apiNames.ADMIN.SETTINGS.READ, user);
   const settings = await prisma.adminSetting.findMany();
@@ -29,7 +30,7 @@ export const load = async ({ locals }) => {
           }
         : undefined,
     updateForm: await superValidate(updateSchema),
-    updateNollningPeriodForm: await superValidate(updateNollningPeriodSchema),
+    updateNollningForm: await superValidate(updateNollningPeriodSchema),
   };
 };
 

--- a/src/routes/(app)/admin/settings/+page.server.ts
+++ b/src/routes/(app)/admin/settings/+page.server.ts
@@ -1,0 +1,80 @@
+import {
+  NOLLNING_END_KEY,
+  NOLLNING_START_KEY,
+  updateNollningPeriod,
+} from "$lib/utils/adminSettings/nollning.js";
+import apiNames from "$lib/utils/apiNames.js";
+import { authorize } from "$lib/utils/authorization.js";
+import { fail } from "@sveltejs/kit";
+import { message, superValidate } from "sveltekit-superforms/client";
+import { z } from "zod";
+
+export const load = async ({ locals }) => {
+  const { prisma, user } = locals;
+  authorize(apiNames.ADMIN.SETTINGS.READ, user);
+  const settings = await prisma.adminSetting.findMany();
+  const nollningStartStr = settings.find(
+    (setting) => setting.key === NOLLNING_START_KEY,
+  )?.value;
+  const nollningEndStr = settings.find(
+    (setting) => setting.key === NOLLNING_END_KEY,
+  )?.value;
+  return {
+    settings,
+    nollning: {
+      start: nollningStartStr ? new Date(nollningStartStr) : undefined,
+      end: nollningEndStr ? new Date(nollningEndStr) : undefined,
+    },
+    updateForm: await superValidate(updateSchema),
+    updateNollningPeriodForm: await superValidate(updateNollningPeriodSchema),
+  };
+};
+
+const updateSchema = z.object({
+  key: z.string().min(1),
+  value: z.string().min(1),
+});
+const removeSchema = z.object({
+  key: z.string().min(1),
+});
+const updateNollningPeriodSchema = z.object({
+  start: z.date(),
+  end: z.date(),
+});
+
+export const actions = {
+  async update({ locals, request }) {
+    const { prisma } = locals;
+    const form = await superValidate(request, updateSchema);
+    if (!form.valid) return fail(400, { form });
+    await prisma.adminSetting.upsert({
+      where: { key: form.data.key },
+      update: { value: form.data.value },
+      create: { key: form.data.key, value: form.data.value },
+    });
+    return message(form, {
+      message: `Inställning ${form.data.key} uppdaterad`,
+      type: "success",
+    });
+  },
+  async remove({ locals, request }) {
+    const { prisma } = locals;
+    const form = await superValidate(request, removeSchema);
+    if (!form.valid) return fail(400, { form });
+    await prisma.adminSetting.delete({ where: { key: form.data.key } });
+    return message(form, {
+      message: `Inställning ${form.data.key} raderad`,
+      type: "success",
+    });
+  },
+  async updateNollning({ locals, request }) {
+    const { prisma } = locals;
+    const form = await superValidate(request, updateNollningPeriodSchema);
+    if (!form.valid) return fail(400, { form });
+    await updateNollningPeriod(prisma, form.data.start, form.data.end);
+    return message(form, {
+      message: `Nollningsperiod uppdaterad`,
+      type: "success",
+    });
+  },
+};

--- a/src/routes/(app)/admin/settings/+page.server.ts
+++ b/src/routes/(app)/admin/settings/+page.server.ts
@@ -21,10 +21,13 @@ export const load = async ({ locals }) => {
   )?.value;
   return {
     settings,
-    nollning: {
-      start: nollningStartStr ? new Date(nollningStartStr) : undefined,
-      end: nollningEndStr ? new Date(nollningEndStr) : undefined,
-    },
+    nollning:
+      nollningStartStr && nollningEndStr
+        ? {
+            start: new Date(nollningStartStr),
+            end: new Date(nollningEndStr),
+          }
+        : undefined,
     updateForm: await superValidate(updateSchema),
     updateNollningPeriodForm: await superValidate(updateNollningPeriodSchema),
   };

--- a/src/routes/(app)/admin/settings/+page.server.ts
+++ b/src/routes/(app)/admin/settings/+page.server.ts
@@ -2,13 +2,13 @@ import {
   NOLLNING_END_KEY,
   NOLLNING_START_KEY,
   updateNollningPeriod,
-} from "$lib/utils/adminSettings/nollning.js";
-import apiNames from "$lib/utils/apiNames.js";
-import { authorize } from "$lib/utils/authorization.js";
+} from "$lib/utils/adminSettings/nollning";
+import apiNames from "$lib/utils/apiNames";
+import { authorize } from "$lib/utils/authorization";
 import { fail } from "@sveltejs/kit";
 import { message, superValidate } from "sveltekit-superforms/client";
 import { z } from "zod";
-import type { PageServerLoad } from "./$types.js";
+import type { PageServerLoad } from "./$types";
 
 export const load: PageServerLoad = async ({ locals }) => {
   const { prisma, user } = locals;

--- a/src/routes/(app)/admin/settings/+page.svelte
+++ b/src/routes/(app)/admin/settings/+page.svelte
@@ -50,12 +50,6 @@
           value={editingSetting.key}
           readonly
         />
-        <Input
-          label="Value"
-          name="value"
-          value={editingSetting.value}
-          {...$updateConstraints.value}
-          error={$updateErrors.value}
         />
       {:else}
         <h3 class="text-lg font-semibold">Skapa ny</h3>
@@ -65,14 +59,14 @@
           {...$updateConstraints.key}
           error={$updateErrors.key}
         />
-        <Input
-          label="Value"
-          name="value"
-          value={editingSetting ? editingSetting.value : undefined}
-          {...$updateConstraints.value}
-          error={$updateErrors.value}
-        />
       {/if}
+      <Input
+        label="Value"
+        name="value"
+        value={editingSetting ? editingSetting.value : undefined}
+        {...$updateConstraints.value}
+        error={$updateErrors.value}
+      />
       <LoadingButton
         class="btn btn-primary mt-4"
         onClick="default"

--- a/src/routes/(app)/admin/settings/+page.svelte
+++ b/src/routes/(app)/admin/settings/+page.svelte
@@ -1,0 +1,160 @@
+<script lang="ts">
+  import { enhance } from "$app/forms";
+  import DateInput from "$lib/components/DateInput.svelte";
+  import Input from "$lib/components/Input.svelte";
+  import Labeled from "$lib/components/Labeled.svelte";
+  import LoadingButton from "$lib/components/LoadingButton.svelte";
+  import PageHeader from "$lib/components/nav/PageHeader.svelte";
+  import type { AdminSetting } from "@prisma/client";
+  import { superForm } from "sveltekit-superforms/client";
+
+  export let data;
+  let editingSetting: AdminSetting | null = null;
+  console.log(data);
+  const {
+    enhance: updateEnhance,
+    submitting: updateSubmitting,
+    errors: updateErrors,
+    constraints: updateConstraints,
+  } = superForm(data.updateForm);
+  const {
+    enhance: nollningEnhance,
+    submitting: nollningSubmitting,
+    errors: nollningErrors,
+    constraints: nollningConstraints,
+  } = superForm(data.updateNollningForm);
+</script>
+
+<PageHeader title="Admininställningar" />
+
+<div class="flex flex-col gap-4">
+  <form
+    class="form-control gap-2 rounded-box bg-base-300 p-4"
+    method="POST"
+    use:updateEnhance
+    action="?/update"
+  >
+    {#if editingSetting !== null}
+      <div class="flex justify-between">
+        <h3 class="text-lg font-semibold">Redigerar</h3>
+        <button class="btn btn-ghost" on:click={() => (editingSetting = null)}
+          >Sluta redigera
+        </button>
+      </div>
+      <Input
+        class="input-disabled pointer-events-none"
+        label="Key"
+        name="key"
+        value={editingSetting.key}
+        readonly
+      />
+      <Input
+        label="Value"
+        name="value"
+        value={editingSetting.value}
+        {...$updateConstraints.value}
+        error={$updateErrors.value}
+      />
+    {:else}
+      <h3 class="text-lg font-semibold">Skapa ny</h3>
+      <Input
+        label="Key"
+        name="key"
+        {...$updateConstraints.key}
+        error={$updateErrors.key}
+      />
+      <Input
+        label="Value"
+        name="value"
+        value={editingSetting ? editingSetting.value : undefined}
+        {...$updateConstraints.value}
+        error={$updateErrors.value}
+      />
+    {/if}
+    <LoadingButton
+      class="btn btn-primary mt-4"
+      onClick="default"
+      isLoading={$updateSubmitting}
+      type="submit"
+    >
+      {editingSetting !== null ? "Uppdatera" : "Skapa"}
+    </LoadingButton>
+  </form>
+  <table class="table rounded-box bg-base-300">
+    <thead>
+      <tr>
+        <th>Key</th>
+        <th>Value</th>
+        <th>Edit</th>
+        <th>Remove</th>
+      </tr>
+    </thead>
+    {#each data.settings as setting (setting.key)}
+      <tr>
+        <td>{setting.key}</td>
+        <td>{setting.value}</td>
+        <td>
+          <button
+            class="btn btn-ghost"
+            on:click={() => (editingSetting = setting)}
+          >
+            <span class="i-mdi-edit" />
+          </button>
+        </td>
+        <td>
+          <form method="POST" use:enhance action="?/remove">
+            <input type="hidden" name="key" value={setting.key} />
+            <LoadingButton
+              type="submit"
+              class="btn btn-error"
+              onClick="default"
+            >
+              <span class="i-mdi-delete" />
+            </LoadingButton>
+          </form>
+        </td>
+      </tr>
+    {/each}
+  </table>
+
+  <form
+    method="POST"
+    action="?/updateNollning"
+    use:nollningEnhance
+    class="form-control justify-between gap-2 rounded-box bg-base-300 p-4 md:flex-row"
+  >
+    <Labeled
+      label="Nollning start"
+      class="md:flex-1"
+      error={$nollningErrors.start}
+      {...$nollningConstraints.start}
+    >
+      <DateInput
+        name="start"
+        date={data.nollning.start ?? new Date()}
+        {...$nollningConstraints.start}
+      />
+    </Labeled>
+    <Labeled
+      class="md:flex-1"
+      label="Nollning start"
+      error={$nollningErrors.end}
+      {...$nollningConstraints.end}
+    >
+      <DateInput
+        name="end"
+        date={data.nollning.end ?? new Date()}
+        {...$nollningConstraints.end}
+        error={$nollningErrors.end}
+      />
+    </Labeled>
+    <LoadingButton
+      class="btn btn-primary mt-4 self-end"
+      onClick="default"
+      isLoading={$nollningSubmitting}
+      type="submit"
+    >
+      Spara
+    </LoadingButton>
+  </form>
+</div>

--- a/src/routes/(app)/api/stripe/webhooks/+server.ts
+++ b/src/routes/(app)/api/stripe/webhooks/+server.ts
@@ -1,12 +1,12 @@
 // in src/routes/stripe/webhooks/+server.js
 import { env } from "$env/dynamic/private";
-import stripe from "$lib/server/shop/payments/stripe.js";
+import stripe from "$lib/server/shop/payments/stripe";
 import {
   onPaymentCancellation,
   onPaymentFailure,
   onPaymentProcessing,
   onPaymentSuccess,
-} from "$lib/server/shop/payments/stripeWebhooks.js";
+} from "$lib/server/shop/payments/stripeWebhooks";
 import { error, isHttpError, json } from "@sveltejs/kit";
 import type Stripe from "stripe";
 

--- a/src/routes/(app)/documents/+page.server.ts
+++ b/src/routes/(app)/documents/+page.server.ts
@@ -3,7 +3,7 @@ import {
   PUBLIC_BUCKETS_FILES,
 } from "$env/static/public";
 import { fileHandler } from "$lib/files";
-import type { FileData } from "$lib/files/fileHandler.js";
+import type { FileData } from "$lib/files/fileHandler";
 import { error, fail } from "@sveltejs/kit";
 import { message, superValidate } from "sveltekit-superforms/server";
 import { z } from "zod";

--- a/src/routes/(app)/documents/DeleteFileForm.svelte
+++ b/src/routes/(app)/documents/DeleteFileForm.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
   import type { SuperValidated } from "sveltekit-superforms";
   import { superForm } from "sveltekit-superforms/client";
-  import type { DeleteSchema } from "./+page.server.js";
   import * as m from "$paraglide/messages";
+  import type { DeleteSchema } from "./+page.server";
 
   export let data: SuperValidated<DeleteSchema>;
   export let fileId: string;

--- a/src/routes/(app)/events/SmallEventCard.svelte
+++ b/src/routes/(app)/events/SmallEventCard.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { relativeDate } from "$lib/utils/client/datetime.js";
+  import { relativeDate } from "$lib/utils/client/datetime";
   import InterestedGoingButtons from "./InterestedGoingButtons.svelte";
   import InterestedGoingList from "./InterestedGoingList.svelte";
   import MarkdownBody from "$lib/components/MarkdownBody.svelte";

--- a/src/routes/(app)/events/tv/TVEventCard.svelte
+++ b/src/routes/(app)/events/tv/TVEventCard.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { relativeDate } from "$lib/utils/client/datetime.js";
+  import { relativeDate } from "$lib/utils/client/datetime";
   import InterestedGoingList from "../InterestedGoingList.svelte";
   import MarkdownBody from "$lib/components/MarkdownBody.svelte";
   import type { EventWithIncludes } from "../events";

--- a/src/routes/(app)/members/[studentId]/+page.server.ts
+++ b/src/routes/(app)/members/[studentId]/+page.server.ts
@@ -45,6 +45,9 @@ export const load: PageServerLoad = async ({ locals, params }) => {
     prisma.article.findMany({
       where: {
         author: {
+          type: {
+            not: "Custom",
+          },
           member: {
             studentId: studentId,
           },

--- a/src/routes/(app)/members/me/+page.server.ts
+++ b/src/routes/(app)/members/me/+page.server.ts
@@ -1,6 +1,6 @@
 // redirect to /members/studentId with their student id
 
-import { redirect } from "$lib/utils/redirect.js";
+import { redirect } from "$lib/utils/redirect";
 import * as m from "$paraglide/messages";
 import { error } from "@sveltejs/kit";
 

--- a/src/routes/(app)/news/+page.svelte
+++ b/src/routes/(app)/news/+page.svelte
@@ -22,7 +22,7 @@
 <SetPageTitle title={m.news()} />
 
 <div class="space-y-4">
-  <section class="flex flex-col gap-2">
+  <section>
     <form
       method="get"
       class="form-control flex-1 gap-2 md:flex-row md:items-end"

--- a/src/routes/(app)/news/ArticleEditor.svelte
+++ b/src/routes/(app)/news/ArticleEditor.svelte
@@ -9,7 +9,7 @@
   import { superForm } from "sveltekit-superforms/client";
   import Article from "./Article.svelte";
   import AuthorSignature from "$lib/components/AuthorSignature.svelte";
-  import type { AuthorOption } from "./articles.js";
+  import type { AuthorOption } from "./articles";
   import type { ArticleSchema } from "./schema";
   import * as m from "$paraglide/messages";
 

--- a/src/routes/(app)/news/SmallArticleCard.svelte
+++ b/src/routes/(app)/news/SmallArticleCard.svelte
@@ -1,11 +1,10 @@
 <script lang="ts">
-  import DOMPurify from "isomorphic-dompurify";
-  import { getFullName } from "$lib/utils/client/member";
-  import type { Article } from "./articles";
-  import MemberAvatar from "$lib/components/socials/MemberAvatar.svelte";
-  import dayjs from "dayjs";
+  import AuthorSignature from "$lib/components/AuthorSignature.svelte";
   import { goto } from "$lib/utils/redirect";
+  import dayjs from "dayjs";
+  import DOMPurify from "isomorphic-dompurify";
   import { markdownToTxt } from "markdown-to-txt";
+  import type { Article } from "./articles";
   export let article: Article;
 </script>
 
@@ -20,7 +19,7 @@
     </div>
   </div>
 
-  <div class="flex flex-col overflow-hidden p-8">
+  <div class="flex flex-col items-stretch overflow-hidden p-8">
     <div class="flex-1">
       <button
         on:click={() => goto("news/" + article.slug)}
@@ -35,38 +34,22 @@
       </button>
     </div>
 
-    <div class="flex gap-4">
-      <a href={"members/" + article.author.member.studentId}>
-        <MemberAvatar
-          class="size-10 hover:opacity-60"
-          member={article.author.member}
-        />
-      </a>
-      <div class="flex w-full items-center justify-between gap-4">
-        <div>
-          <a href={"members/" + article.author.member.studentId}>
-            <h2 class="text-sm font-semibold text-primary hover:underline">
-              {getFullName(article.author.member)}
-            </h2>
-          </a>
-          {#if article.author.mandate}
-            <a href={"positions/" + article.author.mandate.position.id}>
-              <p class="my-1 text-xs font-light hover:underline">
-                {article.author.mandate.position.name}
-              </p>
-            </a>
-          {/if}
-        </div>
-        <p
-          class="my-1 self-end text-nowrap text-xs font-light text-neutral-600"
-        >
-          {#if dayjs(article.createdAt).diff(dayjs(), "week") < -1}
-            {dayjs(article.createdAt).format("YYYY-MM-DD")}
-          {:else}
-            {dayjs(article.createdAt).fromNow()}
-          {/if}
-        </p>
-      </div>
-    </div>
+    <AuthorSignature
+      member={article.author.member}
+      position={article.author.mandate?.position}
+      customAuthor={article.author.customAuthor ?? undefined}
+      type={article.author.type}
+    >
+      <p
+        class="my-1 self-end text-nowrap text-xs font-light text-neutral-600"
+        slot="end"
+      >
+        {#if dayjs(article.createdAt).diff(dayjs(), "week") < -1}
+          {dayjs(article.createdAt).format("YYYY-MM-DD")}
+        {:else}
+          {dayjs(article.createdAt).fromNow()}
+        {/if}
+      </p>
+    </AuthorSignature>
   </div>
 </article>

--- a/src/routes/(app)/shop/tickets/[slug]/+page@(app).svelte
+++ b/src/routes/(app)/shop/tickets/[slug]/+page@(app).svelte
@@ -8,7 +8,7 @@
   import FoodPreferenceModal from "$lib/components/FoodPreferenceModal.svelte";
   import * as m from "$paraglide/messages";
   import SetPageTitle from "$lib/components/nav/SetPageTitle.svelte";
-  import { eventLink } from "$lib/utils/redirect.js";
+  import { eventLink } from "$lib/utils/redirect";
 
   export let data;
   $: ticket = data.ticket;

--- a/src/routes/(app)/shop/tickets/[slug]/edit/+page.server.ts
+++ b/src/routes/(app)/shop/tickets/[slug]/edit/+page.server.ts
@@ -1,6 +1,6 @@
-import { ticketSchema } from "$lib/components/shop/types.js";
-import apiNames from "$lib/utils/apiNames.js";
-import { authorize } from "$lib/utils/authorization.js";
+import { ticketSchema } from "$lib/components/shop/types";
+import apiNames from "$lib/utils/apiNames";
+import { authorize } from "$lib/utils/authorization";
 import { ShoppableType } from "@prisma/client";
 import { error, fail } from "@sveltejs/kit";
 import { redirect } from "$lib/utils/redirect";

--- a/src/routes/(app)/shop/tickets/[slug]/manage/+page.server.ts
+++ b/src/routes/(app)/shop/tickets/[slug]/manage/+page.server.ts
@@ -2,11 +2,11 @@ import { env } from "$env/dynamic/public";
 import {
   moveQueueToCart,
   withHandledNotificationQueue,
-} from "$lib/server/shop/addToCart/reservations.js";
-import authorizedPrismaClient from "$lib/server/shop/authorizedPrisma.js";
-import { refundConsumable } from "$lib/server/shop/payments/stripeMethods.js";
-import apiNames from "$lib/utils/apiNames.js";
-import { authorize } from "$lib/utils/authorization.js";
+} from "$lib/server/shop/addToCart/reservations";
+import authorizedPrismaClient from "$lib/server/shop/authorizedPrisma";
+import { refundConsumable } from "$lib/server/shop/payments/stripeMethods";
+import apiNames from "$lib/utils/apiNames";
+import { authorize } from "$lib/utils/authorization";
 import type { Event, Shoppable, Ticket } from "@prisma/client";
 import { error, fail } from "@sveltejs/kit";
 import { message, superValidate } from "sveltekit-superforms/server";

--- a/src/routes/(app)/shop/tickets/[slug]/manage/download-csv/+server.ts
+++ b/src/routes/(app)/shop/tickets/[slug]/manage/download-csv/+server.ts
@@ -1,5 +1,5 @@
-import apiNames from "$lib/utils/apiNames.js";
-import { authorize } from "$lib/utils/authorization.js";
+import apiNames from "$lib/utils/apiNames";
+import { authorize } from "$lib/utils/authorization";
 import type {
   Consumable,
   Event,

--- a/src/routes/(app)/shop/tickets/create/+page.server.ts
+++ b/src/routes/(app)/shop/tickets/create/+page.server.ts
@@ -1,6 +1,6 @@
-import { ticketSchema } from "$lib/components/shop/types.js";
-import apiNames from "$lib/utils/apiNames.js";
-import { authorize } from "$lib/utils/authorization.js";
+import { ticketSchema } from "$lib/components/shop/types";
+import apiNames from "$lib/utils/apiNames";
+import { authorize } from "$lib/utils/authorization";
 import { ShoppableType } from "@prisma/client";
 import { fail } from "@sveltejs/kit";
 import dayjs from "dayjs";

--- a/src/routes/routes.ts
+++ b/src/routes/routes.ts
@@ -149,6 +149,13 @@ export const getRoutes = (): Route[] =>
           accessRequired: apiNames.ALERT,
           appBehaviour: "home-link",
         },
+        {
+          title: m.adminSettings(),
+          path: "/admin/settings",
+          icon: "i-mdi-wrench",
+          accessRequired: apiNames.ADMIN.SETTINGS.READ,
+          appBehaviour: "home-link",
+        },
       ],
     },
   ] as const;

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -25,6 +25,7 @@
   "doors": "Doors",
   "emailAliases": "Email alias",
   "alerts": "Alerts",
+  "adminSettings": "Admin settings",
 
   "footer_contact": "Contact",
   "footer_sourceCode": "Source code",

--- a/src/translations/sv.json
+++ b/src/translations/sv.json
@@ -25,6 +25,7 @@
   "doors": "Dörrar",
   "emailAliases": "Mejlaliaser",
   "alerts": "Globala meddelanden",
+  "adminSettings": "Admininställningar",
 
   "footer_contact": "Kontakt",
   "footer_sourceCode": "Källkod",

--- a/src/typings/@zenstackhq.d.ts
+++ b/src/typings/@zenstackhq.d.ts
@@ -6,6 +6,5 @@ declare module "@zenstackhq/runtime" {
     memberId?: string;
     policies: string[];
     externalCode?: string; // for non-authenticated users
-    isNollning?: boolean;
   }
 }

--- a/src/typings/@zenstackhq.d.ts
+++ b/src/typings/@zenstackhq.d.ts
@@ -6,5 +6,6 @@ declare module "@zenstackhq/runtime" {
     memberId?: string;
     policies: string[];
     externalCode?: string; // for non-authenticated users
+    isNollning?: boolean;
   }
 }


### PR DESCRIPTION
This PR adds functionality to hide "staben" during the nollning.

It works in two ways. One, it reads the admin settings table to determine whether or not we are in the nollning period (should start mid-summer, first of july for example, and end on the end of gasque). The dates are specified in the new /admin/settings page. Initially, you will manually have to add "nollning_start" and "nollning_end" keys for it to show up, but then there is a nice UI to change the dates.

Then:
- If we are NOT in the nollning period, give everyone the access policy "member:see_staben"
- IF we are in the nollning period, only those with the correct roles will receive the policy. This is specified at the usual api access policy page.

When one of the following resources are requested, they are denied if the user doesn't have the "see_staben" policy:
- POSITION (If stab position of course)
- MANDATE (If a mandate for a stab position)
- MEMBER (If the member CURRENTLY has a stab mandate)

This also causes an AUTHOR resource with a member who is currently a stab to also get rejected (because Member is not nullable), which in turn causes an ARTICLE resource to also be rejected (author is not nullable). Same goes for everywhere else where AUTHOR is used (like notifications). However, events do not use the author system yet so they are not hidden.

I think this is hiding the stab sufficiently, and other edge-cases should be able to be handled manually.