### PR TITLE
Implement caching system to be used for page load functions

### DIFF
--- a/src/lib/server/loadHomeData.ts
+++ b/src/lib/server/loadHomeData.ts
@@ -1,5 +1,6 @@
 import { PUBLIC_BUCKETS_DOCUMENTS } from "$env/static/public";
 import { fileHandler } from "$lib/files";
+import authorizedPrismaClient from "$lib/server/shop/authorizedPrisma";
 import { BASIC_ARTICLE_FILTER } from "$lib/utils/articles";
 import { CacheDependency } from "$lib/utils/caching/cache";
 import { globallyCached, userLevelCached } from "$lib/utils/caching/cached";
@@ -147,12 +148,15 @@ const _loadHomeData = async (
   );
 
   // CAFE OPENING TIMES
-  const cafeOpenPromise = globallyCached(CacheDependency.CAFE_OPEN_TIMES, () =>
-    prisma.markdown.findFirst({
-      where: {
-        name: `cafe:open:${new Date().getDay() - 1}`, // we assign monday to 0, not sunday
-      },
-    }),
+  const cafeOpenPromise = globallyCached(
+    "cafeOpenTimesToday",
+    () =>
+      authorizedPrismaClient.markdown.findFirst({
+        where: {
+          name: `cafe:open:${new Date().getDay() - 1}`, // we assign monday to 0, not sunday
+        },
+      }),
+    [CacheDependency.CAFE_OPEN_TIMES],
   );
 
   // COMMIT DATA

--- a/src/lib/server/shop/payments/stripeWebhooks.ts
+++ b/src/lib/server/shop/payments/stripeWebhooks.ts
@@ -47,7 +47,6 @@ export const onPaymentSuccess = async (intent: Stripe.PaymentIntent) => {
         });
       }
       return relevantConsumables;
-      // TODO: Notify user of successful payment})
     },
   );
   try {

--- a/src/lib/utils/caching/cache.ts
+++ b/src/lib/utils/caching/cache.ts
@@ -1,0 +1,80 @@
+export type CacheEntry<T> = {
+  value: T;
+  lastFetched: number; // UNIX epoch number (i.e. Date.now() or date.valueOf()). Smaller in memory than storing Date
+  expiresAt: number; // UNIX epoch number (i.e. Date.now() or date.valueOf())
+  dependencies?: string[] | undefined;
+};
+export type CacheStore = Map<string, CacheEntry<unknown>>;
+export type Cache = ReturnType<typeof createCache>;
+type EntryWithKey<T> = CacheEntry<T> & { key: string };
+
+const DEFAULT_CACHE_TIMEOUT = 1000 * 60 * 5; // 5 minutes
+
+export const createCache = (cache: CacheStore) => {
+  const isCacheKeyValid = (key: string, at: number = Date.now()): boolean => {
+    const entry = cache.get(key) as EntryWithKey<unknown>;
+    if (!entry) return false;
+    entry.key = key;
+    return isCacheEntryValid(entry, at);
+  };
+
+  const isCacheEntryValid = (
+    entry: CacheEntry<unknown> | undefined,
+    at: number = Date.now(),
+  ): boolean => {
+    if (!entry) return false;
+    if (entry.expiresAt < at) return false;
+    return true;
+  };
+
+  const updateCacheEntry = <T>(
+    key: string,
+    value: T,
+    at: number = Date.now(),
+    cacheTimeout: number = DEFAULT_CACHE_TIMEOUT,
+    dependencies?: string | string[],
+  ) => {
+    const entry = cache.get(key);
+    if (entry && entry.lastFetched > at) return; // stored value is newer
+    cache.set(key, {
+      value,
+      lastFetched: at,
+      expiresAt: at + cacheTimeout,
+      dependencies:
+        typeof dependencies === "string" ? [dependencies] : dependencies,
+    });
+    return value;
+  };
+
+  const invalidateCacheEntry = (
+    dependency: string,
+    at: number = Date.now(),
+  ) => {
+    for (const [key, entry] of cache) {
+      if (
+        key === dependency ||
+        (entry.dependencies && entry.dependencies.includes(dependency))
+      ) {
+        if (entry.lastFetched > at) continue; // stored is newer
+        cache.set(key, {
+          ...entry,
+          expiresAt: at,
+        });
+      }
+    }
+  };
+  return {
+    get: cache.get.bind(cache),
+    isKeyValid: isCacheKeyValid,
+    isEntryValid: isCacheEntryValid,
+    update: updateCacheEntry,
+    invalidate: invalidateCacheEntry,
+  };
+};
+
+export enum CacheDependency {
+  NEWS = "news",
+  EVENTS = "events",
+  MEETINGS = "meetings",
+  CAFE_OPEN_TIMES = "cafeOpenTimes",
+}

--- a/src/lib/utils/caching/cache.ts
+++ b/src/lib/utils/caching/cache.ts
@@ -72,9 +72,14 @@ export const createCache = (cache: CacheStore) => {
   };
 };
 
+// I REALLY recommend using this enum (and adding values as necessary) instead of writing manual strings
+// It gives a clear overview of what type of dependencies are used throughout the project when caching stuff
 export enum CacheDependency {
   NEWS = "news",
   EVENTS = "events",
   MEETINGS = "meetings",
   CAFE_OPEN_TIMES = "cafeOpenTimes",
+  ALERTS = "alerts",
+  NOTIFICATIONS = "notifications",
+  CONSUMABLES = "consumables", // includes reservations as well
 }

--- a/src/lib/utils/caching/cached.ts
+++ b/src/lib/utils/caching/cached.ts
@@ -1,7 +1,8 @@
-import type { CacheEntry } from "$lib/utils/caching/cache";
+import { TIME_IN_MS, type CacheEntry } from "$lib/utils/caching/cache";
 import globalCache from "$lib/utils/caching/globalCache";
 import {
   invalidateUserCaches,
+  pruneUserCaches,
   userCache,
 } from "$lib/utils/caching/userSpecificCaches";
 import type { AuthUser } from "@zenstackhq/runtime";
@@ -77,3 +78,17 @@ export const invalidateDependency = (
   globalCache.invalidate(dependency, at);
   invalidateUserCaches(dependency, at);
 };
+
+/**
+ * "Prunes" all caches, ie removing all expired entries. Should be run somewhat regularly.
+ * The reason why we want to prune is because our cache system would cause a "memory leak", storing very old and obscure cache entries for no reason.
+ */
+export const pruneAllCaches = () => {
+  globalCache.prune();
+  pruneUserCaches();
+};
+
+// Prune every 30 minutes. Could definitely be changed.
+setInterval(() => {
+  pruneAllCaches();
+}, TIME_IN_MS.THIRY_MINUTES);

--- a/src/lib/utils/caching/cached.ts
+++ b/src/lib/utils/caching/cached.ts
@@ -1,0 +1,79 @@
+import type { CacheEntry } from "$lib/utils/caching/cache";
+import globalCache from "$lib/utils/caching/globalCache";
+import {
+  invalidateUserCaches,
+  userCache,
+} from "$lib/utils/caching/userSpecificCaches";
+import type { AuthUser } from "@zenstackhq/runtime";
+
+/**
+ * Handles caching of the given callback method. The cached value is stored globally for all users.
+ * @param key A unique key for this resource. If the keys are the same we assume the other parameters to also be the same.
+ * @param fetchData Callback method to get the resource.
+ * @param dependencies Keys of other cache methods which this depends on, this will be a cache miss if any of those are cache misses.
+ * @param cacheTimeout How long this resource should be kept in cache.
+ * @returns
+ */
+export const globallyCached = async <T, Args extends unknown[]>(
+  key: string,
+  fetchData: (...args: Args) => Promise<T>,
+  dependencies?: string | string[] | undefined,
+  cacheTimeout?: number | undefined,
+  ...args: Args
+): Promise<T> => {
+  const entry = globalCache.get(key) as CacheEntry<T>;
+  if (globalCache.isEntryValid(entry)) return entry!.value;
+  console.warn(
+    "GLOBAL CACHE MISS!",
+    key,
+    entry?.expiresAt ? entry.expiresAt < Date.now() : undefined,
+  );
+  const fetchedAt = Date.now();
+  const result = await fetchData(...args);
+  globalCache.update(key, result, fetchedAt, cacheTimeout, dependencies);
+  return result;
+};
+
+/**
+ * Handles caching of the given callback method. The stored values are cached on a per-user basis.
+ * @param key A unique key for this resource. If the keys are the same we assume the other parameters to also be the same.
+ * @param fetchData Callback method to get the resource.
+ * @param dependencies Keys of other cache methods which this depends on, this will be a cache miss if any of those are cache misses.
+ * @param cacheTimeout How long this resource should be kept in cache.
+ * @returns
+ */
+export const userLevelCached = async <T, Args extends unknown[]>(
+  user: AuthUser,
+  key: string,
+  fetchData: (user: AuthUser, ...args: Args) => Promise<T>,
+  dependencies?: string | string[] | undefined,
+  cacheTimeout?: number | undefined,
+  ...args: Args
+): Promise<T> => {
+  if (!user.memberId)
+    // anonymous user
+    return globallyCached(
+      key,
+      fetchData,
+      dependencies,
+      cacheTimeout,
+      user,
+      ...args,
+    );
+  const cache = userCache(user.memberId);
+  const entry = cache.get(key) as CacheEntry<T> | undefined;
+  if (cache.isEntryValid(entry)) return entry!.value;
+  console.warn("CACHE MISS!", key, entry);
+  const fetchedAt = Date.now();
+  const result = await fetchData(user, ...args);
+  cache.update(key, result, fetchedAt, cacheTimeout, dependencies);
+  return result;
+};
+
+export const invalidateDependency = (
+  dependency: string,
+  at: number = Date.now(),
+) => {
+  globalCache.invalidate(dependency, at);
+  invalidateUserCaches(dependency, at);
+};

--- a/src/lib/utils/caching/globalCache.ts
+++ b/src/lib/utils/caching/globalCache.ts
@@ -1,0 +1,12 @@
+import {
+  createCache,
+  type Cache,
+  type CacheEntry,
+  type CacheStore,
+} from "./cache";
+
+const globalCacheStore: CacheStore = new Map<string, CacheEntry<unknown>>();
+
+const globalCache: Cache = createCache(globalCacheStore);
+
+export default globalCache;

--- a/src/lib/utils/caching/userSpecificCaches.ts
+++ b/src/lib/utils/caching/userSpecificCaches.ts
@@ -1,0 +1,20 @@
+import { createCache, type Cache, type CacheEntry } from "./cache";
+
+const userCacheStores: Record<string, Cache> = {};
+export const userCache = (key: string) => {
+  const cache = userCacheStores[key];
+  if (cache) return cache!;
+  const store = new Map<string, CacheEntry<unknown>>();
+  const newCache: Cache = createCache(store);
+  userCacheStores[key] = newCache;
+  return newCache;
+};
+
+export const invalidateUserCaches = (
+  dependency: string,
+  at: number = Date.now(),
+) => {
+  Object.keys(userCacheStores).forEach((key) => {
+    userCache(key).invalidate(dependency, at);
+  });
+};

--- a/src/lib/utils/caching/userSpecificCaches.ts
+++ b/src/lib/utils/caching/userSpecificCaches.ts
@@ -18,3 +18,9 @@ export const invalidateUserCaches = (
     userCache(key).invalidate(dependency, at);
   });
 };
+
+export const pruneUserCaches = () => {
+  for (const [key, cache] of Object.entries(userCacheStores)) {
+    if (cache.prune()) delete userCacheStores[key];
+  }
+};

--- a/src/routes/(app)/+layout.server.ts
+++ b/src/routes/(app)/+layout.server.ts
@@ -1,3 +1,4 @@
+import authorizedPrismaClient from "$lib/server/shop/authorizedPrisma";
 import { countUserShopItems } from "$lib/server/shop/countUserShopItems";
 import { CacheDependency } from "$lib/utils/caching/cache";
 import { globallyCached, userLevelCached } from "$lib/utils/caching/cached";
@@ -58,7 +59,7 @@ export const load = loadFlash(async ({ locals, depends, url }) => {
     prisma,
   );
   const alerts = await globallyCached(CacheDependency.ALERTS, () =>
-    prisma.alert.findMany({
+    authorizedPrismaClient.alert.findMany({
       where: {
         removedAt: null,
       },

--- a/src/routes/(app)/board/+page.server.ts
+++ b/src/routes/(app)/board/+page.server.ts
@@ -102,6 +102,7 @@ const loadBoardMembers = async (_: unknown, prisma: PrismaClient) => {
   mergedBoardPositions.sort((a, b) =>
     compareBoardPositions(a.position.id, b.position.id),
   );
+  return mergedBoardPositions;
 };
 
 export const load: PageServerLoad = async ({ locals }) => {

--- a/src/routes/(app)/committees/+page.server.ts
+++ b/src/routes/(app)/committees/+page.server.ts
@@ -1,31 +1,39 @@
+import authorizedPrismaClient from "$lib/server/shop/authorizedPrisma";
+import { CacheDependency, TIME_IN_MS } from "$lib/utils/caching/cache";
+import { globallyCached } from "$lib/utils/caching/cached";
 import type { PageServerLoad } from "./$types";
 
-export const load: PageServerLoad = async ({ locals }) => {
-  const { prisma } = locals;
-  const committees = await prisma.committee.findMany({
-    include: {
-      positions: {
-        select: {
-          mandates: {
-            where: {
-              startDate: {
-                lte: new Date(),
-              },
-              endDate: {
-                gte: new Date(),
+export const load: PageServerLoad = async () => {
+  const committees = await globallyCached(
+    "committees",
+    () =>
+      authorizedPrismaClient.committee.findMany({
+        include: {
+          positions: {
+            select: {
+              mandates: {
+                where: {
+                  startDate: {
+                    lte: new Date(),
+                  },
+                  endDate: {
+                    gte: new Date(),
+                  },
+                },
+                select: {
+                  memberId: true,
+                },
               },
             },
-            select: {
-              memberId: true,
+            orderBy: {
+              name: "asc",
             },
           },
         },
-        orderBy: {
-          name: "asc",
-        },
-      },
-    },
-  });
+      }),
+    [CacheDependency.MANDATES_AND_POSITIONS],
+    TIME_IN_MS.ONE_HOUR,
+  );
   return {
     committees,
   };

--- a/src/routes/(app)/committees/[shortName]/+page.server.ts
+++ b/src/routes/(app)/committees/[shortName]/+page.server.ts
@@ -1,12 +1,13 @@
 import type { PageServerLoad } from "./$types";
 import { committeeActions, committeeLoad } from "../committee.server";
 
-export const load: PageServerLoad = (request) => {
-  const yearQuery = request.url.searchParams.get("year");
+export const load: PageServerLoad = ({ url, locals, params }) => {
+  const { user, prisma } = locals;
+  const yearQuery = url.searchParams.get("year");
   const parsedYear = parseInt(yearQuery ?? "");
   const year = isNaN(parsedYear) ? new Date().getFullYear() : parsedYear;
 
-  return committeeLoad(request.locals.prisma, request.params.shortName, year);
+  return committeeLoad(user, prisma, params.shortName, year);
 };
 
 export const actions = committeeActions();

--- a/src/routes/(app)/committees/cafe/+page.server.ts
+++ b/src/routes/(app)/committees/cafe/+page.server.ts
@@ -1,22 +1,30 @@
 import type { PageServerLoad } from "./$types";
 import { committeeActions, committeeLoad } from "../committee.server";
+import { globallyCached } from "$lib/utils/caching/cached";
+import authorizedPrismaClient from "$lib/server/shop/authorizedPrisma";
+import { CacheDependency } from "$lib/utils/caching/cache";
 
 export const load: PageServerLoad = async ({ locals, url }) => {
-  const { prisma } = locals;
+  const { user, prisma } = locals;
   const yearQuery = url.searchParams.get("year");
   const parsedYear = parseInt(yearQuery ?? "");
   const year = isNaN(parsedYear) ? new Date().getFullYear() : parsedYear;
-  const openingHours = prisma.markdown.findMany({
-    where: {
-      name: {
-        startsWith: "cafe:open",
-      },
-    },
-    orderBy: {
-      name: "asc",
-    },
-  });
-  return committeeLoad(prisma, "cafe", year).then(async (data) => ({
+  const openingHours = globallyCached(
+    "cafeOpenTimes",
+    () =>
+      authorizedPrismaClient.markdown.findMany({
+        where: {
+          name: {
+            startsWith: "cafe:open",
+          },
+        },
+        orderBy: {
+          name: "asc",
+        },
+      }),
+    [CacheDependency.CAFE_OPEN_TIMES],
+  );
+  return committeeLoad(user, prisma, "cafe", year).then(async (data) => ({
     ...data,
     openingHours: await openingHours,
   }));

--- a/src/routes/(app)/documents/+page.server.ts
+++ b/src/routes/(app)/documents/+page.server.ts
@@ -21,6 +21,7 @@ const prefixByType: Record<DocumentType, string> = {
   "SRD-meeting": "Möte ",
   other: "",
 };
+// TODO: Cache
 export const load: PageServerLoad = async ({ locals, url }) => {
   const { user } = locals;
   const year = url.searchParams.get("year") || new Date().getFullYear();

--- a/src/routes/(app)/documents/governing/+page.server.ts
+++ b/src/routes/(app)/documents/governing/+page.server.ts
@@ -4,6 +4,7 @@ import { message, superValidate } from "sveltekit-superforms/server";
 import { z } from "zod";
 import * as m from "$paraglide/messages";
 
+// TODO: Cache
 export const load: PageServerLoad = async ({ locals }) => {
   const { prisma } = locals;
   const governingDocuments = await prisma.document

--- a/src/routes/(app)/documents/requirements/+page.server.ts
+++ b/src/routes/(app)/documents/requirements/+page.server.ts
@@ -18,6 +18,7 @@ export type FolderType = {
   files: FolderType[];
 };
 
+// TODO: Cache
 export const load: PageServerLoad = async ({ locals, url }) => {
   const { user } = locals;
   const year = url.searchParams.get("year") || new Date().getFullYear();

--- a/src/routes/(app)/events/[slug]/+page.server.ts
+++ b/src/routes/(app)/events/[slug]/+page.server.ts
@@ -14,6 +14,7 @@ import apiNames from "$lib/utils/apiNames";
 import { removeEventAction, removeEventSchema } from "../removeEventAction";
 import * as m from "$paraglide/messages";
 
+// TODO: Cache
 export const load: PageServerLoad = async ({ locals, params }) => {
   const { prisma, user } = locals;
   const event = await getEvent(prisma, params.slug);

--- a/src/routes/(app)/events/tv/+page.server.ts
+++ b/src/routes/(app)/events/tv/+page.server.ts
@@ -1,6 +1,7 @@
 import { getAllEvents } from "../events";
 import type { PageServerLoad } from "./$types";
 
+// TODO: Cache
 export const load: PageServerLoad = async ({ locals }) => {
   const { prisma } = locals;
   const [events] = await getAllEvents(prisma);

--- a/src/routes/(app)/home/+page.server.ts
+++ b/src/routes/(app)/home/+page.server.ts
@@ -6,6 +6,5 @@ export const load: PageServerLoad = async ({ locals, fetch }) => {
   if (!locals.user?.memberId) {
     redirect(302, "/");
   }
-  const res = await loadHomeData({ locals, fetch });
-  return res;
+  return await loadHomeData({ locals, fetch });
 };

--- a/src/routes/(app)/home/+page.server.ts
+++ b/src/routes/(app)/home/+page.server.ts
@@ -6,5 +6,6 @@ export const load: PageServerLoad = async ({ locals, fetch }) => {
   if (!locals.user?.memberId) {
     redirect(302, "/");
   }
-  return await loadHomeData({ locals, fetch });
+  const res = await loadHomeData({ locals, fetch });
+  return res;
 };

--- a/src/routes/(app)/info/[slug]/+page.server.ts
+++ b/src/routes/(app)/info/[slug]/+page.server.ts
@@ -1,6 +1,7 @@
 import { error } from "@sveltejs/kit";
 import type { PageServerLoad } from "./$types";
 
+// TODO: Cache
 export const load: PageServerLoad = async ({ locals, params }) => {
   const { prisma } = locals;
   const markdownPage = await prisma.markdown.findUnique({

--- a/src/routes/(app)/members/+page.server.ts
+++ b/src/routes/(app)/members/+page.server.ts
@@ -4,6 +4,7 @@ import * as m from "$paraglide/messages";
 
 const allowedProgrammes = ["D", "C", "VR/AR"];
 
+// TODO: Cache
 export const load: PageServerLoad = async (request) => {
   const { prisma, user } = request.locals;
   if (!user?.memberId) {

--- a/src/routes/(app)/members/[studentId]/+page.server.ts
+++ b/src/routes/(app)/members/[studentId]/+page.server.ts
@@ -10,6 +10,7 @@ import keycloak from "$lib/server/keycloak";
 import { z } from "zod";
 import * as m from "$paraglide/messages";
 
+// TODO: Cache
 export const load: PageServerLoad = async ({ locals, params }) => {
   const { prisma, user } = locals;
   const { studentId } = params;

--- a/src/routes/(app)/news/+page.server.ts
+++ b/src/routes/(app)/news/+page.server.ts
@@ -13,6 +13,7 @@ const getAndValidatePage = (url: URL) => {
   return page ? Math.max(Number.parseInt(page) - 1, 0) : undefined;
 };
 
+// TODO: Cache
 export const load: PageServerLoad = async ({ locals, url }) => {
   const { prisma } = locals;
   const [[articles, pageCount], allTags] = await Promise.all([

--- a/src/routes/(app)/news/[slug]/+page.server.ts
+++ b/src/routes/(app)/news/[slug]/+page.server.ts
@@ -18,6 +18,7 @@ import {
 } from "../removeArticleAction";
 import * as m from "$paraglide/messages";
 
+// TODO: Cache
 export const load: PageServerLoad = async ({ locals, params }) => {
   const { prisma, user } = locals;
   const article = await getArticle(prisma, params.slug);

--- a/src/routes/(app)/news/tv/+page.server.ts
+++ b/src/routes/(app)/news/tv/+page.server.ts
@@ -1,6 +1,7 @@
 import type { PageServerLoad } from "./$types";
 import { getAllArticles } from "../articles";
 
+// TODO: Cache
 export const load: PageServerLoad = async ({ locals }) => {
   const { prisma } = locals;
   const [articles] = await getAllArticles(prisma);

--- a/src/routes/(app)/settings/+page.server.ts
+++ b/src/routes/(app)/settings/+page.server.ts
@@ -3,6 +3,7 @@ import { fail } from "@sveltejs/kit";
 import { authorize } from "$lib/utils/authorization";
 import apiNames from "$lib/utils/apiNames";
 
+// TODO: Cache
 export const load: PageServerLoad = async ({ locals }) => {
   const { user, prisma } = locals;
   authorize(apiNames.MEMBER.UPDATE, user);

--- a/src/routes/(app)/shop/tickets/+page.server.ts
+++ b/src/routes/(app)/shop/tickets/+page.server.ts
@@ -14,6 +14,7 @@ import type { PageServerLoad } from "./$types";
 import * as m from "$paraglide/messages";
 import { countUserShopItems } from "$lib/server/shop/countUserShopItems";
 
+// TODO: Cache
 export const load: PageServerLoad = async ({ locals, depends }) => {
   const { user, prisma } = locals;
   const { memberId, externalCode } = user ?? {};

--- a/src/routes/(app)/shop/tickets/[slug]/+page.server.ts
+++ b/src/routes/(app)/shop/tickets/[slug]/+page.server.ts
@@ -2,6 +2,7 @@ import { error } from "@sveltejs/kit";
 import type { PageServerLoad } from "./$types";
 import { getTicket } from "$lib/server/shop/getTickets";
 import * as m from "$paraglide/messages";
+// TODO: Cache
 
 export const load: PageServerLoad = async ({ locals, params, depends }) => {
   const { prisma, user } = locals;

--- a/src/routes/(app)/songbook/+page.server.ts
+++ b/src/routes/(app)/songbook/+page.server.ts
@@ -6,6 +6,7 @@ import { canAccessDeletedSongs, getExistingCategories } from "./helpers";
 
 const SONGS_PER_PAGE = 10;
 
+// TODO: Cache
 export const load: PageServerLoad = async ({ locals, url }) => {
   const { prisma, user } = locals;
   const page = url.searchParams.get("page");


### PR DESCRIPTION
This PR adds a naive in-memory caching system which works like this:

You have an async method you would like to cache, 99% a database request but does work for stuff like Github commit data etc.

You have to decide, is this data user-specific or global? (For example, alerts are global because we want every visitor to see the same alerts, most data is user-specific due to our access system)

Depending on the answer you either wrap your async call in a `globallyCached(...)` or `userLevelCached(...)` method. What this does is save the return value in an in-memory cache on the server, and next time it's called does a cache query first.

The cache system is purged every so often, and cache lifetime is set per-resource (with a default of 5 minutes IIRC)