### PR TITLE
Suggested fix for Link Shortener's tag filtering

### DIFF
--- a/src/routes/(app)/admin/links/+page.server.ts
+++ b/src/routes/(app)/admin/links/+page.server.ts
@@ -41,15 +41,10 @@ const paramsSchema = z.object({
 });
 
 const getParams = (url: URL) => {
-  const modifiedParams = Object.fromEntries(
-    Array.from(url.searchParams.entries()).map(([key, value]) => [
-      key,
-      key === "tags" ? url.searchParams.getAll(key) : value,
-    ]),
-  );
-
-  const { data: params, error: paramError } =
-    paramsSchema.safeParse(modifiedParams);
+  const { data: params, error: paramError } = paramsSchema.safeParse({
+    ...Object.fromEntries(url.searchParams.entries()),
+    tags: url.searchParams.getAll("tags"), // Allow multiple tags
+  });
   if (paramError) {
     throw error(422, paramError.errors.map((e) => e.message).join(". "));
   }

--- a/src/routes/(app)/admin/links/+page.server.ts
+++ b/src/routes/(app)/admin/links/+page.server.ts
@@ -41,8 +41,21 @@ const paramsSchema = z.object({
 });
 
 const getParams = (url: URL) => {
+  let modifiedParams: { [k: string]: string | string[] } = {}
+  url.searchParams.forEach((value, key) => {
+    if (key === "tags") {
+      if (modifiedParams[key] && Array.isArray(modifiedParams[key])) {
+        modifiedParams[key].push(value)
+      } else {
+        modifiedParams[key] = [value]
+      }
+    } else {
+      modifiedParams[key] = value
+    }
+  });
+
   const { data: params, error: paramError } = paramsSchema.safeParse(
-    Object.fromEntries(url.searchParams.entries()),
+    modifiedParams
   );
   if (paramError) {
     throw error(422, paramError.errors.map((e) => e.message).join(". "));

--- a/src/routes/(app)/admin/links/+page.server.ts
+++ b/src/routes/(app)/admin/links/+page.server.ts
@@ -41,18 +41,12 @@ const paramsSchema = z.object({
 });
 
 const getParams = (url: URL) => {
-  let modifiedParams: { [k: string]: string | string[] } = {}
-  url.searchParams.forEach((value, key) => {
-    if (key === "tags") {
-      if (modifiedParams[key] && Array.isArray(modifiedParams[key])) {
-        modifiedParams[key].push(value)
-      } else {
-        modifiedParams[key] = [value]
-      }
-    } else {
-      modifiedParams[key] = value
-    }
-  });
+  const modifiedParams = Object.fromEntries(
+    Array.from(url.searchParams.entries()).map(([key, value]) => [
+      key,
+      key === "tags" ? url.searchParams.getAll(key) : value
+    ])
+  )
 
   const { data: params, error: paramError } = paramsSchema.safeParse(
     modifiedParams

--- a/src/routes/(app)/admin/links/+page.server.ts
+++ b/src/routes/(app)/admin/links/+page.server.ts
@@ -44,13 +44,12 @@ const getParams = (url: URL) => {
   const modifiedParams = Object.fromEntries(
     Array.from(url.searchParams.entries()).map(([key, value]) => [
       key,
-      key === "tags" ? url.searchParams.getAll(key) : value
-    ])
-  )
-
-  const { data: params, error: paramError } = paramsSchema.safeParse(
-    modifiedParams
+      key === "tags" ? url.searchParams.getAll(key) : value,
+    ]),
   );
+
+  const { data: params, error: paramError } =
+    paramsSchema.safeParse(modifiedParams);
   if (paramError) {
     throw error(422, paramError.errors.map((e) => e.message).join(". "));
   }


### PR DESCRIPTION
Fix for #485. Converts `tags` parameters into an `Array`, as is expected by the `paramsSchema`.