### PR TITLE
Fixed #512

### DIFF
--- a/src/routes/(app)/members/[studentId]/edit-bio/+page.server.ts
+++ b/src/routes/(app)/members/[studentId]/edit-bio/+page.server.ts
@@ -11,7 +11,9 @@ import * as m from "$paraglide/messages";
 
 export const load: PageServerLoad = async ({ locals, params }) => {
   const { prisma, user } = locals;
-  authorize(apiNames.MEMBER.UPDATE, user);
+  if (user?.studentId !== params.studentId) {
+    authorize(apiNames.MEMBER.UPDATE, user);
+  }
 
   const member = await prisma.member.findUnique({
     where: {


### PR DESCRIPTION
Allows users to access the page `/members/[studentId]/edit-bio` if the `studentId` is their own.