### PR TITLE
Changed meeting type selector styling

### DIFF
--- a/src/routes/(app)/documents/Tabs.svelte
+++ b/src/routes/(app)/documents/Tabs.svelte
@@ -22,7 +22,10 @@
   };
 </script>
 
-<div role="tablist" class="tabs-boxed tabs items-stretch">
+<div
+  role="tablist"
+  class="tabs-boxed flex w-full flex-col items-stretch sm:w-auto sm:flex-row"
+>
   {#each options as tabOption (tabOption.value)}
     <a
       href={generateLink(tabOption.value)}


### PR DESCRIPTION
Tweak styling of meeting type selector to make sure it doesn't go outside the page on smaller screens (i.e. mobile)