### PR TITLE
New column on governing documents page for year specific documents 

### DIFF
--- a/src/database/prisma/schema.prisma
+++ b/src/database/prisma/schema.prisma
@@ -33,6 +33,9 @@ enum DocumentType {
     GUIDELINE
     MEETING
     OTHER
+    PLAN_OF_OPERATIONS
+    FRAMEWORK_BUDGET
+    STRATEGIC_GOALS
     @@map("document_type")
 }
 

--- a/src/database/schema.zmodel
+++ b/src/database/schema.zmodel
@@ -891,6 +891,9 @@ enum DocumentType {
   GUIDELINE
   MEETING
   OTHER
+  PLAN_OF_OPERATIONS
+  FRAMEWORK_BUDGET
+  STRATEGIC_GOALS
 
   @@map("document_type")
 }

--- a/src/database/seed/.snaplet/dataModel.json
+++ b/src/database/seed/.snaplet/dataModel.json
@@ -9100,6 +9100,9 @@
       "schemaName": "public",
       "values": [
         {
+          "name": "FRAMEWORK_BUDGET"
+        },
+        {
           "name": "GUIDELINE"
         },
         {
@@ -9109,7 +9112,13 @@
           "name": "OTHER"
         },
         {
+          "name": "PLAN_OF_OPERATIONS"
+        },
+        {
           "name": "POLICY"
+        },
+        {
+          "name": "STRATEGIC_GOALS"
         }
       ]
     },

--- a/src/routes/(app)/documents/governing/+page.server.ts
+++ b/src/routes/(app)/documents/governing/+page.server.ts
@@ -5,17 +5,38 @@ import { zod } from "sveltekit-superforms/adapters";
 import { z } from "zod";
 import * as m from "$paraglide/messages";
 
-export const load: PageServerLoad = async ({ locals }) => {
+export const load: PageServerLoad = async ({ locals, url }) => {
   const { prisma } = locals;
+  let year = url.searchParams.get("year") || new Date().getFullYear();
+  year = typeof year === "string" ? parseInt(year) : year;
   const governingDocuments = await prisma.document
-    .findMany({ where: { deletedAt: null } })
-    .then((documents) => ({
-      policies: documents.filter((document) => document.type === "POLICY"),
-      guidelines: documents.filter((document) => document.type === "GUIDELINE"),
-    }));
+    .findMany({
+      where: {
+        deletedAt: null,
+      },
+    })
+    .then((documents) => {
+      const filterDocuments = (type: string, filterByDate: boolean) =>
+        documents.filter(
+          (document) =>
+            document.type === type &&
+            (filterByDate ? document.createdAt.getFullYear() == year : true),
+        );
+
+      return {
+        policies: filterDocuments("POLICY", false),
+        guidelines: filterDocuments("GUIDELINE", false),
+        plansOfOperations: filterDocuments("PLAN_OF_OPERATIONS", true),
+        frameworkBudgets: filterDocuments("FRAMEWORK_BUDGET", true),
+        strategicGoals: filterDocuments("STRATEGIC_GOALS", true),
+      };
+    });
 
   return {
     policies: governingDocuments.policies,
+    plansOfOperations: governingDocuments.plansOfOperations,
+    frameworkBudgets: governingDocuments.frameworkBudgets,
+    strategicGoals: governingDocuments.strategicGoals,
     guidelines: governingDocuments.guidelines,
     deleteForm: await superValidate(zod(deleteSchema)),
   };

--- a/src/routes/(app)/documents/governing/+page.server.ts
+++ b/src/routes/(app)/documents/governing/+page.server.ts
@@ -10,11 +10,7 @@ export const load: PageServerLoad = async ({ locals, url }) => {
   let year = url.searchParams.get("year") || new Date().getFullYear();
   year = typeof year === "string" ? parseInt(year) : year;
   const governingDocuments = await prisma.document
-    .findMany({
-      where: {
-        deletedAt: null,
-      },
-    })
+    .findMany()
     .then((documents) => {
       const filterDocuments = (type: string, filterByDate: boolean) =>
         documents.filter(

--- a/src/routes/(app)/documents/governing/+page.svelte
+++ b/src/routes/(app)/documents/governing/+page.svelte
@@ -7,7 +7,14 @@
   import FileWithDownload from "../FileWithDownload.svelte";
   import type { PageData } from "./$types";
   import * as m from "$paraglide/messages";
+  import Pagination from "$lib/components/Pagination.svelte";
   export let data: PageData;
+
+  $: plansOfOperations = data.plansOfOperations;
+  $: strategicGoals = data.strategicGoals;
+  $: frameworkBudgets = data.frameworkBudgets;
+
+  const currentYear = new Date().getFullYear();
 
   let isEditing = false;
   let selectedPdf: string | null = null;
@@ -120,6 +127,92 @@
               <a
                 class="pointer-events-auto"
                 href={`/documents/governing/${guideline.id}/edit`}
+                ><span class="i-mdi-pencil align-middle text-xl text-secondary"
+                ></span>
+              </a>
+            {/if}
+          </div>
+        {/each}
+      </div>
+    </div>
+    <div>
+      <h1 class="my-3 text-2xl font-bold">
+        {m.documents_governing_yearSpecificDocuments()}
+      </h1>
+      <div class="flex flex-col gap-2">
+        <Pagination
+          class="max-w-md"
+          count={currentYear - 1981}
+          getPageName={(pageNumber) => (currentYear - pageNumber).toString()}
+          getPageNumber={(pageName) => currentYear - +pageName}
+          fieldName="year"
+        />
+        {#each plansOfOperations as planOfOperations}
+          <div class="flex items-center gap-1">
+            <FileWithDownload
+              name={planOfOperations.title}
+              url={getPdfApiUrl(planOfOperations.url)}
+              onClick={onPdfClick}
+            />
+            {#if isAuthorized(apiNames.GOVERNING_DOCUMENT.DELETE, data.user) && isEditing}
+              <DeleteFileForm
+                fileId={planOfOperations.id}
+                fileName={planOfOperations.title}
+                data={data.deleteForm}
+              />
+            {/if}
+            {#if isAuthorized(apiNames.GOVERNING_DOCUMENT.UPDATE, data.user) && isEditing}
+              <a
+                class="pointer-events-auto"
+                href={`/documents/governing/${planOfOperations.id}/edit`}
+                ><span class="i-mdi-pencil align-middle text-xl text-secondary"
+                ></span>
+              </a>
+            {/if}
+          </div>
+        {/each}
+        {#each frameworkBudgets as frameworkBudget}
+          <div class="flex items-center gap-1">
+            <FileWithDownload
+              name={frameworkBudget.title}
+              url={getPdfApiUrl(frameworkBudget.url)}
+              onClick={onPdfClick}
+            />
+            {#if isAuthorized(apiNames.GOVERNING_DOCUMENT.DELETE, data.user) && isEditing}
+              <DeleteFileForm
+                fileId={frameworkBudget.id}
+                fileName={frameworkBudget.title}
+                data={data.deleteForm}
+              />
+            {/if}
+            {#if isAuthorized(apiNames.GOVERNING_DOCUMENT.UPDATE, data.user) && isEditing}
+              <a
+                class="pointer-events-auto"
+                href={`/documents/governing/${frameworkBudget.id}/edit`}
+                ><span class="i-mdi-pencil align-middle text-xl text-secondary"
+                ></span>
+              </a>
+            {/if}
+          </div>
+        {/each}
+        {#each strategicGoals as strategicGoal}
+          <div class="flex items-center gap-1">
+            <FileWithDownload
+              name={strategicGoal.title}
+              url={getPdfApiUrl(strategicGoal.url)}
+              onClick={onPdfClick}
+            />
+            {#if isAuthorized(apiNames.GOVERNING_DOCUMENT.DELETE, data.user) && isEditing}
+              <DeleteFileForm
+                fileId={strategicGoal.id}
+                fileName={strategicGoal.title}
+                data={data.deleteForm}
+              />
+            {/if}
+            {#if isAuthorized(apiNames.GOVERNING_DOCUMENT.UPDATE, data.user) && isEditing}
+              <a
+                class="pointer-events-auto"
+                href={`/documents/governing/${strategicGoal.id}/edit`}
                 ><span class="i-mdi-pencil align-middle text-xl text-secondary"
                 ></span>
               </a>

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -546,7 +546,7 @@
   "documents_governing_forQuestions": "If you have question or thoughts about the governing documents you can contact ",
   "documents_governing_pdfViewer": "PDF viewer",
   "documents_governing_errors_notFound": "Governing document not found",
-  "documents_governing_yearSpecificDocuments": "Year specific documents",
+  "documents_governing_yearSpecificDocuments": "Yearly documents",
   "songbook_songCreated": "Song crated",
   "songbook_title": "Title",
   "songbook_melody": "Melody",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -546,6 +546,7 @@
   "documents_governing_forQuestions": "If you have question or thoughts about the governing documents you can contact ",
   "documents_governing_pdfViewer": "PDF viewer",
   "documents_governing_errors_notFound": "Governing document not found",
+  "documents_governing_yearSpecificDocuments": "Year specific documents",
   "songbook_songCreated": "Song crated",
   "songbook_title": "Title",
   "songbook_melody": "Melody",

--- a/src/translations/sv.json
+++ b/src/translations/sv.json
@@ -544,6 +544,7 @@
   "documents_governing_forQuestions": "Om du har några frågor eller funderingar kring styrdokumenten kan du kontakta ",
   "documents_governing_pdfViewer": "PDF-visare",
   "documents_governing_errors_notFound": "Kunde inte hitta styrdokumentet",
+  "documents_governing_yearSpecificDocuments": "Årsspecifika dokument",
   "songbook_songCreated": "Sång skapad",
   "songbook_title": "Titel",
   "songbook_melody": "Melodi",


### PR DESCRIPTION
Implemented #549.
![image](https://github.com/user-attachments/assets/b85e938d-1f06-45ab-89de-6a2497068574)
All relevant documents still need to be manually added to the database.