### PR TITLE
Add videos to articles

### DIFF
--- a/src/database/prisma/schema.prisma
+++ b/src/database/prisma/schema.prisma
@@ -148,6 +148,7 @@ model Article {
     body String
     bodyEn String? @map("body_en")
     imageUrl String? @map("image_url") @db.Text()
+    videoUrl String? @map("video_url") @db.Text()
     authorId String @map("author_id") @db.Uuid()
     publishedAt DateTime? @map("published_datetime") @db.Timestamptz(6)
     updatedAt DateTime? @map("latest_edit_datetime") @db.Timestamptz(6)

--- a/src/database/schema.zmodel
+++ b/src/database/schema.zmodel
@@ -118,6 +118,7 @@ model Article {
   body        String
   bodyEn      String?          @map("body_en")
   imageUrl    String?          @map("image_url") @db.Text
+  videoUrl    String?          @map("video_url") @db.Text
   authorId    String           @map("author_id") @db.Uuid
   publishedAt DateTime?        @map("published_datetime") @db.Timestamptz(6)
   updatedAt   DateTime?        @map("latest_edit_datetime") @db.Timestamptz(6)

--- a/src/database/seed/.snaplet/dataModel.json
+++ b/src/database/seed/.snaplet/dataModel.json
@@ -1684,6 +1684,20 @@
           "maxLength": null
         },
         {
+          "id": "public.articles.video_url",
+          "name": "video_url",
+          "columnName": "video_url",
+          "type": "text",
+          "isRequired": false,
+          "kind": "scalar",
+          "isList": false,
+          "isGenerated": false,
+          "sequence": false,
+          "hasDefaultValue": false,
+          "isId": false,
+          "maxLength": null
+        },
+        {
           "name": "authors",
           "type": "authors",
           "isRequired": true,

--- a/src/lib/files/utils.ts
+++ b/src/lib/files/utils.ts
@@ -1,4 +1,5 @@
 export const isFileImage = (file: File) => file.type.split("/")[0] === "image";
+export const isFileVideo = (file: File) => file.type.split("/")[0] === "video";
 
 export const getNameOfFile = (fileName: string) => {
   const dotIndex = fileName.lastIndexOf(".");

--- a/src/lib/news/schema.ts
+++ b/src/lib/news/schema.ts
@@ -1,4 +1,4 @@
-import { isFileImage } from "$lib/files/utils";
+import { isFileImage, isFileVideo } from "$lib/files/utils";
 import { authorSchema, tagSchema } from "$lib/zod/schemas";
 import type { Infer } from "sveltekit-superforms";
 import { z } from "zod";
@@ -25,6 +25,13 @@ export const articleSchema = z.object({
     .optional()
     .refine((file) => !file || isFileImage(file), {
       message: "Måste vara en bild",
+    }),
+  video: z
+    .instanceof(File, { message: "Please upload a file" })
+    .nullable()
+    .optional()
+    .refine((file) => !file || isFileVideo(file), {
+      message: "Måste vara en video",
     }),
 });
 export type ArticleSchema = Infer<typeof articleSchema>;

--- a/src/routes/(app)/news/Article.svelte
+++ b/src/routes/(app)/news/Article.svelte
@@ -8,7 +8,13 @@
   export let article: Article;
 </script>
 
-{#if article.imageUrl}
+{#if article.videoUrl}
+  <figure>
+    <video autoplay muted controls src={getFileUrl(article.videoUrl)}>
+      <track kind="captions" />
+    </video>
+  </figure>
+{:else if article.imageUrl}
   <figure>
     <img
       class="mx-auto"

--- a/src/routes/(app)/news/ArticleEditor.svelte
+++ b/src/routes/(app)/news/ArticleEditor.svelte
@@ -17,6 +17,7 @@
     dataType: "json",
   });
   let articleImage: string | undefined = undefined;
+  let articleVideo: string | undefined = undefined;
   const { form } = superform;
 </script>
 
@@ -24,7 +25,13 @@
   class="container mx-auto flex flex-col gap-8 px-4 pt-8 lg:flex-row [&>*]:flex-1"
 >
   <section>
-    <ArticleForm {superform} {allTags} {authorOptions} bind:articleImage>
+    <ArticleForm
+      {superform}
+      {allTags}
+      {authorOptions}
+      bind:articleImage
+      bind:articleVideo
+    >
       <slot slot="form-end" name="form-end" />
     </ArticleForm>
   </section>
@@ -45,6 +52,7 @@
         removedAt: null,
         status: "draft",
         imageUrl: articleImage ?? $form.imageUrl ?? null,
+        videoUrl: articleVideo ?? $form.imageUrl ?? null,
       }}
     >
       <AuthorSignature

--- a/src/routes/(app)/news/ArticleForm.svelte
+++ b/src/routes/(app)/news/ArticleForm.svelte
@@ -16,6 +16,7 @@
   export let allTags: Tag[];
   export let superform: SuperForm<ArticleSchema>;
   export let articleImage: string | undefined = undefined;
+  export let articleVideo: string | undefined = undefined;
 
   const { form, enhance, errors } = superform;
 
@@ -49,6 +50,31 @@
         );
       } else {
         articleImage = result;
+      }
+    };
+  };
+
+  const onVideoFileSelected = (
+    event: Event & {
+      currentTarget: EventTarget & HTMLInputElement;
+    },
+  ) => {
+    let video = event.currentTarget.files?.[0];
+    if (!video) return;
+    let reader = new FileReader();
+    reader.readAsDataURL(video);
+    reader.onload = (e) => {
+      let result = e.target?.result ?? undefined;
+      // If array buffer, convert to base64
+      if (result instanceof ArrayBuffer) {
+        articleVideo = btoa(
+          new Uint8Array(result).reduce(
+            (data, byte) => data + String.fromCharCode(byte),
+            "",
+          ),
+        );
+      } else {
+        articleVideo = result;
       }
     };
   };
@@ -115,6 +141,14 @@
     label="Bild"
     onChange={onFileSelected}
     accept="image/*"
+  />
+
+  <FormFileInput
+    {superform}
+    field="video"
+    label="Video"
+    onChange={onVideoFileSelected}
+    accept="video/*"
   />
 
   <slot name="form-end" />


### PR DESCRIPTION
Fixed #479. Allows the user to specify both a video and an image but will only show the video in the main article viewer.