### PR TITLE
Cafe buggy editing

### DIFF
--- a/src/routes/(app)/committees/EditCommitteeForm.svelte
+++ b/src/routes/(app)/committees/EditCommitteeForm.svelte
@@ -19,6 +19,7 @@
   const superform = superForm(formData, {
     validators: zodClient(updateSchema),
     resetForm: false,
+    id: "generic",
   });
   const { form, enhance } = superform;
 </script>


### PR DESCRIPTION
Might've solved issues in #519 and #532. Problem is there are 2 forms on the same page, when submitting one of them, the other might reset, ending up with empty input fields. I've added an id to one of the forms and I can't replicate the issue anymore, or find any more.

Closes #519 and #532