### PR TITLE
Fix landing page color bug on light mode

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -196,7 +196,7 @@
           </a>
           <a
             href="/info/for-foretag"
-            class="py-3 font-medium md:self-center lg:text-xl"
+            class="py-3 font-medium text-[#bfbfbf] md:self-center lg:text-xl"
           >
             {m.home_forCompanies()}
           </a>
@@ -400,6 +400,7 @@
 
     background: rgba(29, 26, 27, 0.6);
     backdrop-filter: blur(4px);
+    color: #bfbfbf;
   }
 
   header {


### PR DESCRIPTION
When switching to light mode and then viewing the landing page (by signing out), some text elements are dark, making them unreadable. This apparently also occurs on some versions of Safari (although I haven't seen this myself).