### PR TITLE
fix: don't seed production

### DIFF
--- a/src/database/seed/helpers.ts
+++ b/src/database/seed/helpers.ts
@@ -1,0 +1,34 @@
+import { exec } from "child_process";
+import util from "util";
+
+/**
+ * Checks for an active SSH tunnel to a PostgreSQL database.
+ * @throws {Error} If such a tunnel is detected.
+ */
+export const checkForPostgresTunnel = async () => {
+  try {
+    /**
+     * lsof means "list open files", the -i flag lists ip-sockets
+     * grep is used to filter the results to only show SSH tunnels to a PostgreSQL database
+     */
+    const ipSockets = await util.promisify(exec)(
+      "lsof -i | grep -E 'ssh.*:postgresq?l? \\(LISTEN\\)'",
+    );
+
+    /**
+     * When an SSH tunnel through the PostgreSQL port (5432) is open,
+     * the following should be returned, hence the length === 3 (there's one empty line) check.
+          ssh     71212 username    4u  IPv6 986506      0t0  TCP ip6-localhost:postgresql (LISTEN)
+          ssh     71212 username    5u  IPv4 986507      0t0  TCP localhost:postgresql (LISTEN)
+
+     */
+    if (ipSockets.stdout.split("\n").length === 3) {
+      throw new Error(
+        "Cancelled seeding: A PostgreSQL SSH tunnel was detected! You may be accidentally connected to the production database.",
+      );
+    }
+  } catch {
+    // Ignore the error because exec fails with exit code 1 if no matching process is found.
+    // This is expected when there is no Postgres SSH tunnel running.
+  }
+};

--- a/src/database/seed/main.ts
+++ b/src/database/seed/main.ts
@@ -13,23 +13,10 @@ import {
   models,
   POLICYS,
 } from "./data";
-import { exec } from "child_process";
-import util from "util";
+import { checkForPostgresTunnel } from "./helpers";
 
 const main = async () => {
-  try {
-    const ipSockets = await util.promisify(exec)(
-      "lsof -i | grep -E 'ssh.*:postgresq?l? \\(LISTEN\\)'",
-    );
-    if (ipSockets.stdout.split("\n").length === 3) {
-      console.log(
-        "\x1b[41mPostgres ssh tunnel detected, might be production database. Cancelled seeding\x1b[0m",
-      );
-      process.exit(1);
-    }
-  } catch {
-    // ignore error, this is here because exec fails with exit code 1 if nothing is returned
-  }
+  await checkForPostgresTunnel();
 
   const seed = await createSeedClient({
     connect: true,

--- a/src/database/seed/main.ts
+++ b/src/database/seed/main.ts
@@ -13,8 +13,24 @@ import {
   models,
   POLICYS,
 } from "./data";
+import { exec } from "child_process";
+import util from "util";
 
 const main = async () => {
+  try {
+    const ipSockets = await util.promisify(exec)(
+      "lsof -i | grep -E 'ssh.*:postgresq?l? \\(LISTEN\\)'",
+    );
+    if (ipSockets.stdout.split("\n").length === 3) {
+      console.log(
+        "\x1b[41mPostgres ssh tunnel detected, might be production database. Cancelled seeding\x1b[0m",
+      );
+      process.exit(1);
+    }
+  } catch {
+    // ignore error, this is here because exec fails with exit code 1 if nothing is returned
+  }
+
   const seed = await createSeedClient({
     connect: true,
     models,


### PR DESCRIPTION
closes #629

Some explanation:
`lsof` means "list open files", the `-i` flag lists ip-sockets
`grep -E 'ssh.*:postgresq?l? \(LISTEN\)'` is more self explanatory, filtering the output of ``lsof -i` according to the regex

When an ssh tunnel through the postgres port (5432) is open the following should be returned, hence the `length === 3` (there's one empty line) check. 
```
ssh     71212 isak    4u  IPv6 986506      0t0  TCP ip6-localhost:postgresql (LISTEN)
ssh     71212 isak    5u  IPv4 986507      0t0  TCP localhost:postgresql (LISTEN)

```
If there's no tunnel nothing should be returned.

I have tried this on linux and wsl and it seems to be working, but other people with different environments are welcome to try it out (not against production of course) to make sure it works. You can try it out by running `pnpm seed` while having a tunnel open through port 5432, for example with the following command:
```
ssh -N you@NOTPROD -L 5432:localhost:5432
```
