### PR TITLE
Expense update bug

### DIFF
--- a/src/routes/(app)/expenses/[id]/+page.server.ts
+++ b/src/routes/(app)/expenses/[id]/+page.server.ts
@@ -58,13 +58,7 @@ export const actions = {
       include: {
         expense: {
           include: {
-            member: {
-              select: {
-                id: true,
-                firstName: true,
-                lastName: true,
-              },
-            },
+            member: { select: { id: true, firstName: true, lastName: true } },
           },
         },
       },

--- a/src/routes/(app)/expenses/baseItem.ts
+++ b/src/routes/(app)/expenses/baseItem.ts
@@ -1,12 +1,10 @@
-import { COST_CENTERS } from "./config";
 import type { ReceiptRowSchema, ReceiptSchema } from "./types";
-export const createBasicReceiptRow = (
-  costCenter: string = COST_CENTERS[0]!.name,
-): ReceiptRowSchema => ({
-  costCenter,
-  amount: 0,
-  comment: null,
-});
+export const createBasicReceiptRow = (costCenter: string | null = null) =>
+  ({
+    costCenter,
+    amount: 0,
+    comment: null,
+  }) as ReceiptRowSchema;
 const createBasicReceipt = (): ReceiptSchema => ({
   image: null as unknown as File,
   rows: [createBasicReceiptRow()],

--- a/src/routes/(app)/expenses/helper.ts
+++ b/src/routes/(app)/expenses/helper.ts
@@ -4,7 +4,7 @@ import { NotificationType } from "$lib/utils/notifications/types";
 import type { Expense, Member } from "@prisma/client";
 
 export const sendNotificationToSigner = async (
-  member: Member,
+  member: Pick<Member, "id" | "firstName" | "lastName">,
   expense: Pick<Expense, "description">,
   memberIds: string[],
 ) => {

--- a/src/routes/(app)/expenses/types.ts
+++ b/src/routes/(app)/expenses/types.ts
@@ -4,9 +4,13 @@ import { z } from "zod";
 import { isValidCostCenter } from "./config";
 
 const itemSchema = z.object({
-  costCenter: z.string().refine(isValidCostCenter, {
-    message: "Ogiltigt kostnadscenter",
-  }),
+  costCenter: z
+    .string({
+      message: "Välj kostnadsställe",
+    })
+    .refine(isValidCostCenter, {
+      message: "Ogiltigt kostnadscenter",
+    }),
   amount: z.number(),
   comment: z.string().nullable(),
 });

--- a/src/routes/(app)/expenses/types.ts
+++ b/src/routes/(app)/expenses/types.ts
@@ -5,12 +5,8 @@ import { isValidCostCenter } from "./config";
 
 const itemSchema = z.object({
   costCenter: z
-    .string({
-      message: "Välj kostnadsställe",
-    })
-    .refine(isValidCostCenter, {
-      message: "Ogiltigt kostnadscenter",
-    }),
+    .string({ message: "Välj kostnadsställe" })
+    .refine(isValidCostCenter, { message: "Ogiltigt kostnadscenter" }),
   amount: z.number(),
   comment: z.string().nullable(),
 });

--- a/src/routes/(app)/expenses/upload/+page.server.ts
+++ b/src/routes/(app)/expenses/upload/+page.server.ts
@@ -69,7 +69,7 @@ const uploadReceipt = async (
       resize: {
         width: 1920,
         height: 1920,
-        fit: "contain",
+        fit: "outside",
       },
     },
   );

--- a/src/routes/(app)/expenses/upload/+page.server.ts
+++ b/src/routes/(app)/expenses/upload/+page.server.ts
@@ -65,13 +65,7 @@ const uploadReceipt = async (
     expensePhotoUrl(date, id),
     PUBLIC_BUCKETS_FILES,
     undefined,
-    {
-      resize: {
-        width: 1920,
-        height: 1920,
-        fit: "outside",
-      },
-    },
+    { resize: { width: 1920, height: 1920, fit: "outside" } },
   );
   return imageUrl;
 };

--- a/src/routes/(app)/expenses/upload/ExpenseReceiptRow.svelte
+++ b/src/routes/(app)/expenses/upload/ExpenseReceiptRow.svelte
@@ -10,6 +10,16 @@
   export let receiptIndex: number;
   export let index: number;
   export let onRemove: (() => void) | undefined;
+  const options = [
+    {
+      label: "Välj kostnadsställe",
+      value: null,
+    },
+    ...COST_CENTERS.map((center) => ({
+      label: `${center.name} - ${center.description} (${center.example})`,
+      value: center.name,
+    })),
+  ];
 </script>
 
 <div class="-mx-4 border-b border-base-100 px-4 py-2">
@@ -17,10 +27,7 @@
     {superform}
     field={`receipts[${receiptIndex}].rows[${index}].costCenter`}
     label="Kostnadscenter"
-    options={COST_CENTERS.map((center) => ({
-      label: `${center.name} - ${center.description} (${center.example})`,
-      value: center.name,
-    }))}
+    {options}
   />
   <FormNumberInput
     {superform}

--- a/src/routes/(app)/expenses/upload/ExpenseReceiptRow.svelte
+++ b/src/routes/(app)/expenses/upload/ExpenseReceiptRow.svelte
@@ -11,10 +11,7 @@
   export let index: number;
   export let onRemove: (() => void) | undefined;
   const options = [
-    {
-      label: "Välj kostnadsställe",
-      value: null,
-    },
+    { label: "Välj kostnadsställe", value: null },
     ...COST_CENTERS.map((center) => ({
       label: `${center.name} - ${center.description} (${center.example})`,
       value: center.name,


### PR DESCRIPTION
This PR builds upon the expenses system. It fixes a bug where when updating an expense receipt, the person performing the action would be counted as the signer when calculating the new signer.

This PR also fixes some small issues:
- Default cost center is no longer AKTU01 but instead `null` (showing "Välj kostnadsställe")
- Uploaded images were scaled incorrectly, using "contain" meant black bars. I changed this to "inside" which scales down the image until width and height is both below 1920. 