### PR TITLE
Make the `report a bug` buttons point to templates

### DIFF
--- a/src/lib/components/home/CodeWithDWWW.svelte
+++ b/src/lib/components/home/CodeWithDWWW.svelte
@@ -30,7 +30,7 @@
     >
     <a
       class="btn btn-ghost btn-sm"
-      href="https://github.com/Dsek-LTH/web/issues/new"
+      href="https://github.com/Dsek-LTH/web/issues/new/choose"
       ><span
         class="i-mdi-bug text-lg max-lg:text-secondary lg:text-primary xl:text-secondary"
       />

--- a/src/lib/components/layout/ErrorPage.svelte
+++ b/src/lib/components/layout/ErrorPage.svelte
@@ -28,7 +28,7 @@
     <div class="pb-2">{m.error_should_not_happen()}</div>
     <div class="flex flex-row items-center gap-3">
       <a
-        href="https://github.com/Dsek-LTH/web/issues/new"
+        href="https://github.com/Dsek-LTH/web/issues/new/choose"
         class="btn btn-ghost text-lg"
       >
         {m.error_create_issue()} <span class="i-mdi-bug" />


### PR DESCRIPTION
Make the `report a bug` button on the home and 404 pages point to existing templates.
fixes #585 