### PR TITLE
Search tweaks

### DIFF
--- a/src/lib/search/sync.ts
+++ b/src/lib/search/sync.ts
@@ -63,11 +63,34 @@ const sync = async () => {
 
   await waitForTasks(
     () =>
-      indexWithData.map((pair) =>
-        pair.index.updateSearchableAttributes(pair.searchAbleAttributes),
+      indexWithData.map((i) =>
+        i.index.updateSearchableAttributes(i.searchableAttributes),
       ),
     "Updating searchable attributes",
   );
+
+  for (const i of indexWithData) {
+    if (i.sortableAttributes.length > 0) {
+      await waitForTasks(
+        () => [i.index.resetSortableAttributes()],
+        `Resetting sortable attributes for ${i.index.uid}`,
+      );
+      await waitForTasks(
+        () => [i.index.updateSortableAttributes(i.sortableAttributes)],
+        `Updating sortable attributes for ${i.index.uid}`,
+      );
+    }
+    if (i.rankingRules.length > 0) {
+      await waitForTasks(
+        () => [i.index.resetRankingRules()],
+        `Resetting ranking rules for ${i.index.uid}`,
+      );
+      await waitForTasks(
+        () => [i.index.updateRankingRules(i.rankingRules)],
+        `Updating ranking rules for ${i.index.uid}`,
+      );
+    }
+  }
 
   console.log(`Meilisearch: Data synced. Took ${Date.now() - currentTime} ms`);
   return JSON.stringify(indexWithData);
@@ -135,38 +158,61 @@ async function getRelevantSearchData() {
     positionsIndex,
     committeesIndex,
   ];
+  // These are the default ranking rules for Meilisearch
+  // They are built in, but can be overridden
+  const defaultRankingRules = [
+    "words",
+    "typo",
+    "proximity",
+    "attribute",
+    "exactness",
+  ];
   const indexWithData = [
     {
       index: membersIndex,
       documents: members,
-      searchAbleAttributes: memberSearchableAttributes,
+      searchableAttributes: memberSearchableAttributes,
+      rankingRules: defaultRankingRules.concat([
+        "classYear:desc", // Give a higher weight to newer members
+      ]),
+      sortableAttributes: ["classYear"],
     },
     {
       index: songsIndex,
       documents: songs,
-      searchAbleAttributes: songSearchableAttributes,
+      searchableAttributes: songSearchableAttributes,
+      rankingRules: [],
+      sortableAttributes: [],
     },
     {
       index: articlesIndex,
       documents: articles,
-      searchAbleAttributes: articleSearchableAttributes,
+      searchableAttributes: articleSearchableAttributes,
+      rankingRules: [],
+      sortableAttributes: [],
     },
     {
       index: eventsIndex,
       documents: events,
-      searchAbleAttributes: eventSearchableAttributes,
+      searchableAttributes: eventSearchableAttributes,
+      rankingRules: [],
+      sortableAttributes: [],
     },
     {
       index: positionsIndex,
       documents: positions,
-      searchAbleAttributes: positionSearchableAttributes,
+      searchableAttributes: positionSearchableAttributes,
+      rankingRules: [],
+      sortableAttributes: [],
     },
     {
       index: committeesIndex,
       documents: committees,
-      searchAbleAttributes: committeeSearchableAttributes,
+      searchableAttributes: committeeSearchableAttributes,
+      rankingRules: [],
+      sortableAttributes: [],
     },
-  ] as const;
+  ];
   return { allIndexes, indexWithData };
 }
 

--- a/src/lib/search/sync.ts
+++ b/src/lib/search/sync.ts
@@ -70,7 +70,7 @@ const sync = async () => {
   );
 
   for (const i of indexWithData) {
-    if (i.sortableAttributes.length > 0) {
+    if (i.sortableAttributes?.length) {
       await waitForTasks(
         () => [i.index.resetSortableAttributes()],
         `Resetting sortable attributes for ${i.index.uid}`,
@@ -80,7 +80,7 @@ const sync = async () => {
         `Updating sortable attributes for ${i.index.uid}`,
       );
     }
-    if (i.rankingRules.length > 0) {
+    if (i.rankingRules?.length) {
       await waitForTasks(
         () => [i.index.resetRankingRules()],
         `Resetting ranking rules for ${i.index.uid}`,
@@ -88,6 +88,16 @@ const sync = async () => {
       await waitForTasks(
         () => [i.index.updateRankingRules(i.rankingRules)],
         `Updating ranking rules for ${i.index.uid}`,
+      );
+    }
+    if (i.typoTolerance !== undefined) {
+      await waitForTasks(
+        () => [i.index.resetTypoTolerance()],
+        `Resetting typo tolerance for ${i.index.uid}`,
+      );
+      await waitForTasks(
+        () => [i.index.updateTypoTolerance(i.typoTolerance)],
+        `Updating typo tolerance for ${i.index.uid}`,
       );
     }
   }
@@ -176,41 +186,46 @@ async function getRelevantSearchData() {
         "classYear:desc", // Give a higher weight to newer members
       ]),
       sortableAttributes: ["classYear"],
+      typoTolerance: {
+        disableOnAttributes: ["studentId"], // Student ID should not have typos
+        minWordSizeForTypos: {
+          // Default is 5 for one, and 9 for two
+          // A query like "Maja" should still match "Maya", and "Erik" should match "Eric"
+          oneTypo: 4,
+          twoTypos: 6,
+        },
+      },
     },
     {
       index: songsIndex,
       documents: songs,
       searchableAttributes: songSearchableAttributes,
-      rankingRules: [],
-      sortableAttributes: [],
     },
     {
       index: articlesIndex,
       documents: articles,
       searchableAttributes: articleSearchableAttributes,
-      rankingRules: [],
-      sortableAttributes: [],
     },
     {
       index: eventsIndex,
       documents: events,
       searchableAttributes: eventSearchableAttributes,
-      rankingRules: [],
-      sortableAttributes: [],
     },
     {
       index: positionsIndex,
       documents: positions,
       searchableAttributes: positionSearchableAttributes,
-      rankingRules: [],
-      sortableAttributes: [],
+      typoTolerance: {
+        disableOnAttributes: ["dsekId"], // Dsek ID should not have typos
+      },
     },
     {
       index: committeesIndex,
       documents: committees,
       searchableAttributes: committeeSearchableAttributes,
-      rankingRules: [],
-      sortableAttributes: [],
+      typoTolerance: {
+        disableOnAttributes: ["shortName"], // Short name should not have typos
+      },
     },
   ];
   return { allIndexes, indexWithData };

--- a/src/routes/(app)/search/+page.server.ts
+++ b/src/routes/(app)/search/+page.server.ts
@@ -23,11 +23,17 @@ export const actions = {
       (index) => data.get(index) === "on",
     );
 
+    // Check how many total results to return
+    const limit: number = Number.parseInt(
+      data.get("limit")?.toString() ?? "20",
+    );
+
     // Check which language to search in and get the correct route
     const apiRoute = i18n.resolveRoute("/api/search", event.locals.language);
     const url = new URL(apiRoute, event.request.url);
     url.searchParams.set("query", query);
     url.searchParams.set("indexes", JSON.stringify(indexes));
+    url.searchParams.set("limit", limit.toString());
     const response = await event.fetch(url);
     if (!response.ok) {
       const responseText = await response.text();

--- a/src/routes/(app)/search/+page.svelte
+++ b/src/routes/(app)/search/+page.svelte
@@ -157,6 +157,9 @@
         <label for={index.index}>{mapIndexToMessage(index.index)}</label>
       </div>
     {/each}
+    <!-- This field limits the number of results per query -->
+    <!-- 20 is the default value in Meilisearch -->
+    <input type="hidden" name="limit" value="20" />
   </div>
   <button class="btn sr-only mb-2 w-full">{m.search_search()}</button>
   {#if form?.results?.length}


### PR DESCRIPTION
Tweaks some stuff about the search.

- Rank newer members higher
  - you probably search for someone who currently studies more often than someone who doesn't
- Tweak typo tolerance for member names
  - by lowering the one-typo-tolerance-value to 4, searching for "Erik" will still yield "Eric". Lowering even futher (i.e. to 3) doesn't make sense to me and will probably lead to worse search results.
- Disallow typos for some attributes
  - attributes such as `studentId` should (IMO) not tolerate typos. If I know the student id of my lab partner and want to find his/hers member page, I should only find that persons profile and not similar ones, since it works like a primary key. (It still tolerates not putting the full student id in the query, i.e. if I search for "al62", I can still get "al6271gr-s" as result, but not if I put in "al61" or "al6271gq-s")
- Make search page server respect the limit parameter

Also fixes inconsistent naming of variables.