### PR TITLE
Reduce data sent to client during search

### DIFF
--- a/src/lib/search/searchTypes.ts
+++ b/src/lib/search/searchTypes.ts
@@ -180,3 +180,23 @@ export type SearchDataWithType =
       type: "committees";
       data: CommitteeSearchReturnAttributes;
     };
+
+export const attributesUsedAsLink: {
+  members: keyof MemberSearchReturnAttributes;
+  events: keyof EventSearchReturnAttributes;
+  articles: keyof ArticleSearchReturnAttributes;
+  songs: keyof SongSearchReturnAttributes;
+  positions: keyof PositionSearchReturnAttributes;
+  committees: keyof CommitteeSearchReturnAttributes;
+} = {
+  members: "studentId",
+  events: "slug",
+  articles: "slug",
+  songs: "slug",
+  positions: "dsekId",
+  committees: "shortName",
+};
+
+export const listOfattributesUsedAsLink: string[] = Object.values(
+  attributesUsedAsLink,
+) satisfies string[];

--- a/src/routes/(app)/api/search/+server.ts
+++ b/src/routes/(app)/api/search/+server.ts
@@ -78,10 +78,10 @@ export const GET: RequestHandler = async ({ url, locals }) => {
         }
 
         // Reduce the amount of data sent to the client
-        // all string values are capped at 60 characters
+        // all string values are truncated to 60 characters
         for (const key of Object.keys(hit)) {
           if (
-            // We musn't cap the attributes that are used as links
+            // We must not truncate attributes that are used as links
             !listOfattributesUsedAsLink.includes(key) &&
             typeof hit[key] === "string"
           ) {

--- a/src/routes/(app)/api/search/+server.ts
+++ b/src/routes/(app)/api/search/+server.ts
@@ -4,7 +4,10 @@ import {
   getFederatedWeight,
   getSearchableAttributes,
 } from "$lib/search/searchHelpers";
-import type { SearchDataWithType } from "$lib/search/searchTypes";
+import {
+  listOfattributesUsedAsLink,
+  type SearchDataWithType,
+} from "$lib/search/searchTypes";
 
 /**
  * This endpoint is used to search multiple indexes at once.
@@ -73,6 +76,19 @@ export const GET: RequestHandler = async ({ url, locals }) => {
           }
           hit = hitCopy;
         }
+
+        // Reduce the amount of data sent to the client
+        // all string values are capped at 60 characters
+        for (const key of Object.keys(hit)) {
+          if (
+            // We musn't cap the attributes that are used as links
+            !listOfattributesUsedAsLink.includes(key) &&
+            typeof hit[key] === "string"
+          ) {
+            hit[key] = hit[key].slice(0, 60);
+          }
+        }
+
         return {
           data: hit,
           type: hit._federation?.indexUid,


### PR DESCRIPTION
Slices string attributes (which aren't used as link) to 60 characters. Why 60? It's less but still gives a nice preview in the search results. If we were to slice strings that are used as links, we might return a borken link.