### PR TITLE
Refactor search sync to try to reduce memory usage and hash ids

### DIFF
--- a/src/lib/search/searchHelpers.ts
+++ b/src/lib/search/searchHelpers.ts
@@ -11,8 +11,6 @@ import {
 } from "./searchTypes";
 import * as m from "$paraglide/messages";
 
-import crypto from "crypto";
-
 export type SearchIndex =
   (typeof availableSearchIndexes)[keyof typeof availableSearchIndexes];
 
@@ -141,7 +139,6 @@ export function mapIndexToMessage(index: SearchableIndex) {
 }
 
 /**
- * WARNING: This is non-reversible.
  * Meilisearch has constraints on the id field:
  * it can only contain alphanumeric characters (a-z, A-Z, 0-9), hyphens (-), and underscores (_).
  * So we need to convert the prisma id to a meilisearch id.
@@ -149,9 +146,5 @@ export function mapIndexToMessage(index: SearchableIndex) {
  * It contains dots (.) and possibly swedish characters (åäö).
  */
 export function prismaIdToMeiliId(id: string) {
-  const hashed = crypto.createHash("md5").update(id).digest("hex");
-  if (!hashed.match(/^[a-zA-Z0-9_-]+$/)) {
-    console.log(`Meilisearch: Id ${id} from Prisma is not compatible`);
-  }
-  return hashed;
+  return btoa(id).replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "");
 }

--- a/src/lib/search/searchHelpers.ts
+++ b/src/lib/search/searchHelpers.ts
@@ -11,6 +11,8 @@ import {
 } from "./searchTypes";
 import * as m from "$paraglide/messages";
 
+import crypto from "crypto";
+
 export type SearchIndex =
   (typeof availableSearchIndexes)[keyof typeof availableSearchIndexes];
 
@@ -136,4 +138,20 @@ export function mapIndexToMessage(index: SearchableIndex) {
     default:
       return "";
   }
+}
+
+/**
+ * WARNING: This is non-reversible.
+ * Meilisearch has constraints on the id field:
+ * it can only contain alphanumeric characters (a-z, A-Z, 0-9), hyphens (-), and underscores (_).
+ * So we need to convert the prisma id to a meilisearch id.
+ * As of now, the Positions table has a prisma id that is not compatible with meilisearch.
+ * It contains dots (.) and possibly swedish characters (åäö).
+ */
+export function prismaIdToMeiliId(id: string) {
+  const hashed = crypto.createHash("md5").update(id).digest("hex");
+  if (!hashed.match(/^[a-zA-Z0-9_-]+$/)) {
+    console.log(`Meilisearch: Id ${id} from Prisma is not compatible`);
+  }
+  return hashed;
 }

--- a/src/lib/search/searchTypes.ts
+++ b/src/lib/search/searchTypes.ts
@@ -1,3 +1,22 @@
+/**
+ * This file contains a lot of types and constants.
+ *
+ * Essentially, for every index in Meilisearch there is a type for:
+ *  1. which attributes are stored in Meilisearch for that index,
+ *  2. which attributes a user can search for,
+ *  3. which attributes are returned.
+ *
+ * Of course, all attributes that can be searched for, or are returned,
+ * must be stored in Meilisearch. However, it is not as simble as doing
+ * a union of 2 and 3 to get 1, since some attributes (e.g `event.startDatetime`)
+ * are used purely for sorting and ranking purposes internally by Meilisearch.
+ *
+ * Additionally, there are objects like `memberMeilisearchConstants` which
+ * wraps things related to an index in a single object. Here we can specify
+ * custom ranking and sorting rules for Meili, such as giving newer members
+ * a higher ranking, and tweak which typo tolerance is allowed.
+ */
+
 import type {
   Article,
   Member,

--- a/src/lib/search/searchTypes.ts
+++ b/src/lib/search/searchTypes.ts
@@ -35,6 +35,13 @@ type ObjectKeysNotEndingWith<T, Suffix extends string> = Pick<
 
 type OnlySwedishAttributes<T> = ObjectKeysNotEndingWith<T, "En">;
 
+/**
+ * https://www.totaltypescript.com/concepts/the-prettify-helper
+ */
+type Prettify<T> = {
+  [K in keyof T]: T[K];
+} & {};
+
 export const availableSearchIndexes = [
   "members",
   "events",
@@ -45,106 +52,190 @@ export const availableSearchIndexes = [
 ] as const;
 export type SearchableIndex = (typeof availableSearchIndexes)[number];
 
+// --------------------------------------------------
+// MEMBER
+// --------------------------------------------------
+
+// The order of the attributes in the array is important for ranking
+// The lower the index, the higher the weight
 export const memberSearchableAttributes = [
   "fullName",
   "firstName",
   "lastName",
   "nickname",
   "studentId",
-] as const satisfies Array<keyof Member | "fullName">;
+] as const satisfies Array<keyof MemberDataInMeilisearch>;
 export type SearchableMemberAttributes = FilterKeys<
   Member,
   (typeof memberSearchableAttributes)[number]
 >;
+export type MemberDataInMeilisearch = Prettify<
+  Pick<
+    Member,
+    | "firstName"
+    | "lastName"
+    | "nickname"
+    | "studentId"
+    | "classYear"
+    | "classProgramme"
+    | "picturePath"
+  > & {
+    fullName: `${Member["firstName"]} ${Member["lastName"]}`;
+  }
+>;
+export type MemberSearchReturnAttributes = OnlySwedishAttributes<
+  SearchableMemberAttributes &
+    Pick<
+      MemberDataInMeilisearch,
+      "picturePath" | "classYear" | "classProgramme"
+    >
+>;
 
+// --------------------------------------------------
+// EVENT
+// --------------------------------------------------
+
+// The order of the attributes in the array is important for ranking
+// The lower the index, the higher the weight
 export const eventSearchableAttributes = [
   "title",
   "titleEn",
   "description",
   "descriptionEn",
-] as const satisfies Array<keyof Event>;
+] as const satisfies Array<keyof EventDataInMeilisearch>;
 export type SearchableEventAttributes = Pick<
   Event,
   (typeof eventSearchableAttributes)[number]
 >;
+export type EventDataInMeilisearch = Prettify<
+  Pick<
+    Event,
+    | "title"
+    | "titleEn"
+    | "description"
+    | "descriptionEn"
+    | "slug"
+    | "startDatetime"
+  >
+>;
+export type EventSearchReturnAttributes = OnlySwedishAttributes<
+  SearchableEventAttributes & Pick<EventDataInMeilisearch, "slug">
+>;
 
+// --------------------------------------------------
+// ARTICLE
+// --------------------------------------------------
+
+// The order of the attributes in the array is important for ranking
+// The lower the index, the higher the weight
 export const articleSearchableAttributes = [
   "header",
   "headerEn",
   "body",
   "bodyEn",
-] as const satisfies Array<keyof Article>;
+] as const satisfies Array<keyof ArticleDataInMeilisearch>;
 export type SearchableArticleAttributes = Pick<
   Article,
   (typeof articleSearchableAttributes)[number]
 >;
+export type ArticleDataInMeilisearch = Pick<
+  Article,
+  "header" | "headerEn" | "body" | "bodyEn" | "slug" | "publishedAt"
+>;
+export type ArticleSearchReturnAttributes = OnlySwedishAttributes<
+  SearchableArticleAttributes & Pick<ArticleDataInMeilisearch, "slug">
+>;
 
+// --------------------------------------------------
+// POSITION
+// --------------------------------------------------
+
+// The order of the attributes in the array is important for ranking
+// The lower the index, the higher the weight
 export const positionSearchableAttributes = [
   "name",
   "nameEn",
   "description",
   "descriptionEn",
-  "dsekId",
   "committeeName",
   "committeeNameEn",
-] as const satisfies Array<
-  keyof Position | "dsekId" | "committeeName" | "committeeNameEn"
->;
+  "dsekId",
+] as const satisfies Array<keyof PositionDataInMeilisearch>;
 export type SearchablePositionAttributes = FilterKeys<
   Position,
   (typeof positionSearchableAttributes)[number]
 >;
-
-export const songSearchableAttributes = [
-  "title",
-  "lyrics",
-  "melody",
-  "category",
-] as const satisfies Array<keyof Song>;
-export type SearchableSongAttributes = Pick<
-  Song,
-  (typeof songSearchableAttributes)[number]
+export type PositionDataInMeilisearch = Prettify<
+  Pick<Position, "name" | "nameEn" | "description" | "descriptionEn"> & {
+    committee: Committee | null;
+    dsekId: string;
+    committeeName: Committee["name"];
+    committeeNameEn: Committee["nameEn"];
+  }
+>;
+export type PositionSearchReturnAttributes = OnlySwedishAttributes<
+  SearchablePositionAttributes &
+    Pick<PositionDataInMeilisearch, "committee" | "dsekId">
 >;
 
+// --------------------------------------------------
+// COMMITTEE
+// --------------------------------------------------
+
+// The order of the attributes in the array is important for ranking
+// The lower the index, the higher the weight
 export const committeeSearchableAttributes = [
   "name",
   "nameEn",
   "description",
   "descriptionEn",
-] as const satisfies Array<keyof Committee>;
+] as const satisfies Array<keyof CommitteeDataInMeilisearch>;
 export type SearchableCommitteeAttributes = Pick<
   Committee,
   (typeof committeeSearchableAttributes)[number]
 >;
-
-export type SongSearchReturnAttributes = OnlySwedishAttributes<
-  SearchableSongAttributes & Pick<Song, "slug">
->;
-export type ArticleSearchReturnAttributes = OnlySwedishAttributes<
-  SearchableArticleAttributes & Pick<Article, "slug">
->;
-export type EventSearchReturnAttributes = OnlySwedishAttributes<
-  SearchableEventAttributes & Pick<Event, "slug">
->;
-export type MemberSearchReturnAttributes = OnlySwedishAttributes<
-  SearchableMemberAttributes & {
-    picturePath: Member["picturePath"];
-    classYear: Member["classYear"];
-    classProgramme: Member["classProgramme"];
-  }
->;
-export type PositionSearchReturnAttributes = OnlySwedishAttributes<
-  SearchablePositionAttributes &
-    Pick<Position, "committeeId"> & {
-      committee: Committee | null;
-    }
+export type CommitteeDataInMeilisearch = Prettify<
+  Pick<
+    Committee,
+    | "name"
+    | "nameEn"
+    | "description"
+    | "descriptionEn"
+    | "shortName"
+    | "darkImageUrl"
+    | "lightImageUrl"
+    | "monoImageUrl"
+  >
 >;
 export type CommitteeSearchReturnAttributes = OnlySwedishAttributes<
   SearchableCommitteeAttributes &
     Pick<
-      Committee,
+      CommitteeDataInMeilisearch,
       "shortName" | "darkImageUrl" | "lightImageUrl" | "monoImageUrl"
     >
+>;
+
+// --------------------------------------------------
+// SONG
+// --------------------------------------------------
+
+// The order of the attributes in the array is important for ranking
+// The lower the index, the higher the weight
+export const songSearchableAttributes = [
+  "title",
+  "lyrics",
+  "melody",
+  "category",
+] as const satisfies Array<keyof SongDataInMeilisearch>;
+export type SearchableSongAttributes = Pick<
+  Song,
+  (typeof songSearchableAttributes)[number]
+>;
+export type SongDataInMeilisearch = Prettify<
+  Pick<Song, "title" | "lyrics" | "melody" | "category" | "slug">
+>;
+export type SongSearchReturnAttributes = OnlySwedishAttributes<
+  SearchableSongAttributes & Pick<SongDataInMeilisearch, "slug">
 >;
 
 export type AnySearchReturnAttributes =
@@ -200,3 +291,191 @@ export const attributesUsedAsLink: {
 export const listOfattributesUsedAsLink: string[] = Object.values(
   attributesUsedAsLink,
 ) satisfies string[];
+
+type DefaultRankingRules =
+  | "words"
+  | "typo"
+  | "proximity"
+  | "attribute"
+  | "exactness";
+const defaultRankingRules = [
+  "words",
+  "typo",
+  "proximity",
+  "attribute",
+  "exactness",
+] as const satisfies DefaultRankingRules[];
+
+interface MemberConstantsMeilisearch {
+  searchableAttributes: Array<keyof SearchableMemberAttributes>;
+  rankingRules: Array<
+    DefaultRankingRules | `${keyof MemberDataInMeilisearch}:${"asc" | "desc"}`
+  >;
+  sortableAttributes?: Array<keyof MemberDataInMeilisearch>;
+  typoTolerance?: {
+    disableOnAttributes: Array<keyof SearchableMemberAttributes>;
+    minWordSizeForTypos: {
+      oneTypo: number;
+      twoTypos: number;
+    };
+  };
+}
+
+interface ArticleConstantsMeilisearch {
+  searchableAttributes: Array<keyof SearchableArticleAttributes>;
+  rankingRules: Array<
+    DefaultRankingRules | `${keyof ArticleDataInMeilisearch}:${"asc" | "desc"}`
+  >;
+  sortableAttributes?: Array<keyof ArticleDataInMeilisearch>;
+  typoTolerance?: {
+    disableOnAttributes: Array<keyof SearchableArticleAttributes>;
+    minWordSizeForTypos: {
+      oneTypo: number;
+      twoTypos: number;
+    };
+  };
+}
+
+interface EventConstantsMeilisearch {
+  searchableAttributes: Array<keyof SearchableEventAttributes>;
+  rankingRules: Array<
+    DefaultRankingRules | `${keyof EventDataInMeilisearch}:${"asc" | "desc"}`
+  >;
+  sortableAttributes?: Array<keyof EventDataInMeilisearch>;
+  typoTolerance?: {
+    disableOnAttributes: Array<keyof SearchableEventAttributes>;
+    minWordSizeForTypos: {
+      oneTypo: number;
+      twoTypos: number;
+    };
+  };
+}
+
+interface PositionConstantsMeilisearch {
+  searchableAttributes: Array<keyof SearchablePositionAttributes>;
+  rankingRules: Array<
+    DefaultRankingRules | `${keyof PositionDataInMeilisearch}:${"asc" | "desc"}`
+  >;
+  sortableAttributes?: Array<keyof PositionDataInMeilisearch>;
+  typoTolerance?: {
+    disableOnAttributes: Array<keyof SearchablePositionAttributes>;
+    minWordSizeForTypos: {
+      oneTypo: number;
+      twoTypos: number;
+    };
+  };
+}
+
+interface CommitteeConstantsMeilisearch {
+  searchableAttributes: Array<keyof SearchableCommitteeAttributes>;
+  rankingRules: Array<
+    | DefaultRankingRules
+    | `${keyof CommitteeDataInMeilisearch}:${"asc" | "desc"}`
+  >;
+  sortableAttributes?: Array<keyof CommitteeDataInMeilisearch>;
+  typoTolerance?: {
+    disableOnAttributes: Array<keyof SearchableCommitteeAttributes>;
+    minWordSizeForTypos: {
+      oneTypo: number;
+      twoTypos: number;
+    };
+  };
+}
+
+interface SongConstantsMeilisearch {
+  searchableAttributes: Array<keyof SearchableSongAttributes>;
+  rankingRules: Array<
+    DefaultRankingRules | `${keyof SongDataInMeilisearch}:${"asc" | "desc"}`
+  >;
+  sortableAttributes?: Array<keyof SongDataInMeilisearch>;
+  typoTolerance?: {
+    disableOnAttributes: Array<keyof SearchableSongAttributes>;
+    minWordSizeForTypos: {
+      oneTypo: number;
+      twoTypos: number;
+    };
+  };
+}
+
+const memberMeilisearchConstants: MemberConstantsMeilisearch = {
+  searchableAttributes: memberSearchableAttributes,
+  rankingRules: [
+    ...defaultRankingRules,
+    "classYear:desc", // Give a higher weight to newer members
+  ],
+  sortableAttributes: ["classYear"],
+  typoTolerance: {
+    disableOnAttributes: ["studentId"], // Student ID should not have typos
+    minWordSizeForTypos: {
+      // Default is 5 for one, and 9 for two
+      // A query like "Maja" should still match "Maya", and "Erik" should match "Eric"
+      oneTypo: 4,
+      twoTypos: 6,
+    },
+  },
+};
+
+const articleMeilisearchConstants: ArticleConstantsMeilisearch = {
+  searchableAttributes: articleSearchableAttributes,
+  rankingRules: defaultRankingRules,
+  sortableAttributes: ["publishedAt"],
+};
+
+const eventMeilisearchConstants: EventConstantsMeilisearch = {
+  searchableAttributes: eventSearchableAttributes,
+  rankingRules: [
+    ...defaultRankingRules,
+    "startDatetime:desc", // Give a higher weight to newer events
+  ],
+  sortableAttributes: ["startDatetime"],
+};
+
+const positionMeilisearchConstants: PositionConstantsMeilisearch = {
+  searchableAttributes: positionSearchableAttributes,
+  rankingRules: defaultRankingRules,
+};
+
+const committeeMeilisearchConstants: CommitteeConstantsMeilisearch = {
+  searchableAttributes: committeeSearchableAttributes,
+  rankingRules: defaultRankingRules,
+};
+
+const songMeilisearchConstants: SongConstantsMeilisearch = {
+  searchableAttributes: songSearchableAttributes,
+  rankingRules: defaultRankingRules,
+};
+
+export const meilisearchConstants = {
+  member: memberMeilisearchConstants,
+  article: articleMeilisearchConstants,
+  event: eventMeilisearchConstants,
+  position: positionMeilisearchConstants,
+  committee: committeeMeilisearchConstants,
+  song: songMeilisearchConstants,
+};
+
+export type MeilisearchConstants =
+  | {
+      constants: MemberConstantsMeilisearch;
+      data: MemberDataInMeilisearch;
+    }
+  | {
+      constants: ArticleConstantsMeilisearch;
+      data: ArticleDataInMeilisearch;
+    }
+  | {
+      constants: EventConstantsMeilisearch;
+      data: EventDataInMeilisearch;
+    }
+  | {
+      constants: PositionConstantsMeilisearch;
+      data: PositionDataInMeilisearch;
+    }
+  | {
+      constants: CommitteeConstantsMeilisearch;
+      data: CommitteeDataInMeilisearch;
+    }
+  | {
+      constants: SongConstantsMeilisearch;
+      data: SongDataInMeilisearch;
+    };

--- a/src/lib/search/searchTypes.ts
+++ b/src/lib/search/searchTypes.ts
@@ -306,75 +306,21 @@ const defaultRankingRules = [
   "exactness",
 ] as const satisfies DefaultRankingRules[];
 
-interface MemberConstantsMeilisearch {
-  searchableAttributes: Array<keyof SearchableMemberAttributes>;
-  rankingRules: Array<
-    DefaultRankingRules | `${keyof MemberDataInMeilisearch}:${"asc" | "desc"}`
-  >;
-  sortableAttributes?: Array<keyof MemberDataInMeilisearch>;
-  typoTolerance?: {
-    disableOnAttributes: Array<keyof SearchableMemberAttributes>;
-    minWordSizeForTypos: {
-      oneTypo: number;
-      twoTypos: number;
-    };
-  };
-}
-
-interface ArticleConstantsMeilisearch {
-  searchableAttributes: Array<keyof SearchableArticleAttributes>;
-  rankingRules: Array<
-    DefaultRankingRules | `${keyof ArticleDataInMeilisearch}:${"asc" | "desc"}`
-  >;
-  sortableAttributes?: Array<keyof ArticleDataInMeilisearch>;
-  typoTolerance?: {
-    disableOnAttributes: Array<keyof SearchableArticleAttributes>;
-    minWordSizeForTypos: {
-      oneTypo: number;
-      twoTypos: number;
-    };
-  };
-}
-
-interface EventConstantsMeilisearch {
-  searchableAttributes: Array<keyof SearchableEventAttributes>;
-  rankingRules: Array<
-    DefaultRankingRules | `${keyof EventDataInMeilisearch}:${"asc" | "desc"}`
-  >;
-  sortableAttributes?: Array<keyof EventDataInMeilisearch>;
-  typoTolerance?: {
-    disableOnAttributes: Array<keyof SearchableEventAttributes>;
-    minWordSizeForTypos: {
-      oneTypo: number;
-      twoTypos: number;
-    };
-  };
-}
-
-interface PositionConstantsMeilisearch {
-  searchableAttributes: Array<keyof SearchablePositionAttributes>;
-  rankingRules: Array<
-    DefaultRankingRules | `${keyof PositionDataInMeilisearch}:${"asc" | "desc"}`
-  >;
-  sortableAttributes?: Array<keyof PositionDataInMeilisearch>;
-  typoTolerance?: {
-    disableOnAttributes: Array<keyof SearchablePositionAttributes>;
-    minWordSizeForTypos: {
-      oneTypo: number;
-      twoTypos: number;
-    };
-  };
-}
-
-interface CommitteeConstantsMeilisearch {
-  searchableAttributes: Array<keyof SearchableCommitteeAttributes>;
+/**
+ * Constants for Meilisearch indexes. These are used when tweaking the search
+ * or when getting e.g. the searchable attributes for a specific index.
+ * This interface is used to ensure that the constants are correctly typed.
+ * This may need to be updated if the Meilisearch package changes its namings/APIs.
+ */
+interface IndexConstantsMeilisearch<Searchable, DataInMeilisearch> {
+  searchableAttributes: Array<keyof Searchable>;
   rankingRules: Array<
     | DefaultRankingRules
-    | `${keyof CommitteeDataInMeilisearch}:${"asc" | "desc"}`
+    | `${Extract<keyof DataInMeilisearch, string>}:${"asc" | "desc"}`
   >;
-  sortableAttributes?: Array<keyof CommitteeDataInMeilisearch>;
+  sortableAttributes?: Array<keyof DataInMeilisearch>;
   typoTolerance?: {
-    disableOnAttributes: Array<keyof SearchableCommitteeAttributes>;
+    disableOnAttributes: Array<keyof Searchable>;
     minWordSizeForTypos: {
       oneTypo: number;
       twoTypos: number;
@@ -382,20 +328,33 @@ interface CommitteeConstantsMeilisearch {
   };
 }
 
-interface SongConstantsMeilisearch {
-  searchableAttributes: Array<keyof SearchableSongAttributes>;
-  rankingRules: Array<
-    DefaultRankingRules | `${keyof SongDataInMeilisearch}:${"asc" | "desc"}`
-  >;
-  sortableAttributes?: Array<keyof SongDataInMeilisearch>;
-  typoTolerance?: {
-    disableOnAttributes: Array<keyof SearchableSongAttributes>;
-    minWordSizeForTypos: {
-      oneTypo: number;
-      twoTypos: number;
-    };
-  };
-}
+type MemberConstantsMeilisearch = Prettify<
+  IndexConstantsMeilisearch<SearchableMemberAttributes, MemberDataInMeilisearch>
+>;
+type ArticleConstantsMeilisearch = Prettify<
+  IndexConstantsMeilisearch<
+    SearchableArticleAttributes,
+    ArticleDataInMeilisearch
+  >
+>;
+type EventConstantsMeilisearch = Prettify<
+  IndexConstantsMeilisearch<SearchableEventAttributes, EventDataInMeilisearch>
+>;
+type PositionConstantsMeilisearch = Prettify<
+  IndexConstantsMeilisearch<
+    SearchablePositionAttributes,
+    PositionDataInMeilisearch
+  >
+>;
+type CommitteeConstantsMeilisearch = Prettify<
+  IndexConstantsMeilisearch<
+    SearchableCommitteeAttributes,
+    CommitteeDataInMeilisearch
+  >
+>;
+type SongConstantsMeilisearch = Prettify<
+  IndexConstantsMeilisearch<SearchableSongAttributes, SongDataInMeilisearch>
+>;
 
 const memberMeilisearchConstants: MemberConstantsMeilisearch = {
   searchableAttributes: memberSearchableAttributes,

--- a/src/lib/search/sync.ts
+++ b/src/lib/search/sync.ts
@@ -53,14 +53,6 @@ const sync = async () => {
 
 export default sync;
 
-/**
- * Meilisearch has constraints on the id field:
- * it can only contain alphanumeric characters (a-z, A-Z, 0-9), hyphens (-), and underscores (_).
- * So we need to convert the prisma id to a meilisearch id.
- * As of now, the Positions table has a prisma id that is not compatible with meilisearch.
- * (it contains dots)
- */
-
 async function syncMembers() {
   const numMembers = await authorizedPrismaClient.member.count();
   const membersIndex = await meilisearch.getIndex("members");


### PR DESCRIPTION
Title speaks for itself.

Idea is to divide data in batches and send it one at a time, this way the garbage collector should be able to drop objects since they go out of scope.

Current batch size is 1000, which I think should be fine.

Also hashes ids which should be a (temporary) fix to  #661 