### PR TITLE
Fix: Profile pictures not shown in search results #665

### DIFF
--- a/src/lib/search/searchTypes.test.ts
+++ b/src/lib/search/searchTypes.test.ts
@@ -1,0 +1,29 @@
+import { expect, test } from "vitest";
+import {
+  attributesUsedAsLink,
+  availableSearchIndexes,
+  listOfattributesUsedAsLink,
+} from "./searchTypes";
+
+/**
+ * Test that all indexes has a link attribute
+ * To reduce data sent to client during search
+ * we slice some attributes from the search result
+ * This test makes sure that we don't slice attributes
+ * that are used as links.
+ * All indexes should have at least one such attribute
+ */
+test("all indexes has attribute that doesn't get sliced", () => {
+  for (const index of availableSearchIndexes) {
+    const indexAttributes = attributesUsedAsLink[index];
+    expect(
+      indexAttributes,
+      `Index "${index}" has no attributes that doesn't get sliced`,
+    ).not.toBeUndefined();
+    expect(Array.isArray(indexAttributes)).toBe(true);
+    expect(indexAttributes.length > 0).toBe(true);
+  }
+  expect(listOfattributesUsedAsLink.length).toBeGreaterThanOrEqual(
+    availableSearchIndexes.length,
+  );
+});

--- a/src/lib/search/searchTypes.ts
+++ b/src/lib/search/searchTypes.ts
@@ -291,25 +291,29 @@ export type SearchDataWithType =
       data: CommitteeSearchReturnAttributes;
     };
 
+/**
+ * The server slices strings before sending them to the client
+ * to reduce traffic. Some attributes cannot be sliced however,
+ * since they are used to link to the entry, or e.g. as a image
+ */
 export const attributesUsedAsLink: {
-  members: keyof MemberSearchReturnAttributes;
-  events: keyof EventSearchReturnAttributes;
-  articles: keyof ArticleSearchReturnAttributes;
-  songs: keyof SongSearchReturnAttributes;
-  positions: keyof PositionSearchReturnAttributes;
-  committees: keyof CommitteeSearchReturnAttributes;
+  members: Array<keyof MemberSearchReturnAttributes>;
+  events: Array<keyof EventSearchReturnAttributes>;
+  articles: Array<keyof ArticleSearchReturnAttributes>;
+  songs: Array<keyof SongSearchReturnAttributes>;
+  positions: Array<keyof PositionSearchReturnAttributes>;
+  committees: Array<keyof CommitteeSearchReturnAttributes>;
 } = {
-  members: "studentId",
-  events: "slug",
-  articles: "slug",
-  songs: "slug",
-  positions: "dsekId",
-  committees: "shortName",
+  members: ["studentId", "picturePath"],
+  events: ["slug"],
+  articles: ["slug"],
+  songs: ["slug"],
+  positions: ["dsekId"],
+  committees: ["shortName", "darkImageUrl", "lightImageUrl", "monoImageUrl"],
 };
 
-export const listOfattributesUsedAsLink: string[] = Object.values(
-  attributesUsedAsLink,
-) satisfies string[];
+export const listOfattributesUsedAsLink: string[] =
+  Object.values(attributesUsedAsLink).flat();
 
 type DefaultRankingRules =
   | "words"


### PR DESCRIPTION
Some attributes got sliced during search when they shouldn't have, this PR fixes this. Also adds a test to ensure no index is forgotten