### PR TITLE
Fix link shortener date formatting

### DIFF
--- a/src/routes/(app)/admin/links/+page.svelte
+++ b/src/routes/(app)/admin/links/+page.svelte
@@ -294,7 +294,7 @@
               {d.tags.join(", ")}
             </td>
             <td>
-              {date.getFullYear()}-{String(date.getMonth()).padStart(
+              {date.getFullYear()}-{String(date.getMonth() + 1).padStart(
                 2,
                 "0",
               )}-{String(date.getDate()).padStart(2, "0")}


### PR DESCRIPTION
According to [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getMonth):
> The getMonth() method of [Date](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date) instances returns the month for this date according to local time, as a zero-based value (where zero indicates the first month of the year).

Before:
![2025-01-21T13:37:44,216726686+01:00](https://github.com/user-attachments/assets/d41b55d8-3dbc-4d0c-a9eb-bc6963b081fc)


After:
I have not tested because I do not have an API key for shlink, but I expect that January would be 01, February 02, etc.