### PR TITLE
Update admin door access for 2025

### DIFF
--- a/src/routes/(app)/salto/[door]/constants.ts
+++ b/src/routes/(app)/salto/[door]/constants.ts
@@ -2,6 +2,7 @@
 // and it is chosen by the Head of Faculties (Källarmästare).
 // Do not edit it without consulting them.
 export const BACKUP_LIST_OF_STUDENT_IDS = [
-  "ph3883ni-s", // KM, Philip Nielsen
-  "es1767st-s", // root, Esbjörn Stenberg
+  "ta7116st-s", // KM, Tair Stenlund
+  "ad2313ad-s", // PM (Process Mästare) Daniel Adu-Gyan
+  "to2252ka-s", // root, Tomas Kamsäter
 ];


### PR DESCRIPTION
This has been double checked with current Head of Facilities (Källarmästare).
According to their wishes only Root and Processmästare will be added from the CPU comittee.