### PR TITLE
Add poppler to CI (#778)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,6 +18,14 @@ jobs:
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+
+      - name: Build and push poppler
+        uses: docker/build-push-action@v6
+        with:
+          context: ./poppler-server
+          push: true
+          tags: registry.dsek.se/web/poppler:${{ github.ref_name }},registry.dsek.se/web/poppler:latest
+
       - name: Build and push
         uses: docker/build-push-action@v6
         with:

--- a/poppler-server/index.js
+++ b/poppler-server/index.js
@@ -100,10 +100,6 @@ app.get("/health", async (_req, res) => {
     .send("Server is running.");
 });
 
-app.use((err, _req, res) => {
-  res.status(500).json({ error: err.message });
-});
-
 // Start the server
 app.listen(PORT, () => {
   console.log(`Server is running on http://localhost:${PORT}`);

--- a/src/lib/search/syncDocuments.ts
+++ b/src/lib/search/syncDocuments.ts
@@ -98,7 +98,7 @@ export const syncMeetingDocuments = async () => {
   const files = await fileHandler
     .getInBucket(fileUser, PUBLIC_BUCKETS_DOCUMENTS, "", true)
     .catch((err) => {
-      console.error("Error fetching files", err);
+      console.error("Meilisearch: Error fetching files", err);
       return [];
     });
   const indexName: SearchableIndex = "meetingDocuments";
@@ -110,14 +110,20 @@ export const syncMeetingDocuments = async () => {
       files,
       async (file) => {
         if (file.thumbnailUrl) {
-          const content = await getFileContent(file.thumbnailUrl);
-          if (content) {
-            return {
-              id: prismaIdToMeiliId(file.id),
-              title: file.name,
-              content,
-              url: file.thumbnailUrl,
-            };
+          try {
+            const content = await getFileContent(file.thumbnailUrl);
+            if (content) {
+              return {
+                id: prismaIdToMeiliId(file.id),
+                title: file.name,
+                content,
+                url: file.thumbnailUrl,
+              };
+            }
+          } catch (error) {
+            console.error(
+              `Meilisearch: Error fetching content from ${file.thumbnailUrl}: ${error}`,
+            );
           }
         }
       },
@@ -243,6 +249,10 @@ const checkPopplerHealth = async () => {
       "Poppler: No server URL provided. Check the environment variables",
     );
     return false;
+  } else {
+    console.log(
+      `Poppler: Checking health of server at ${env.POPPLER_SERVER_URL}`,
+    );
   }
   try {
     const response = await fetch(env.POPPLER_SERVER_URL + "/health", {


### PR DESCRIPTION
This broke the deploy pipeline, so I reverted the commit and recreated this pr. I also think it should be a separate job so one build failing does not stop the other.
```
buildx failed with: ERROR: unable to prepare context: path "./poppler-server" not found
```

* add poppler to deploy workflow

* try to improve poppler fault tolerance