### PR TITLE
Fix price calculation and standardize conversions

### DIFF
--- a/src/lib/server/shop/tickets/mutations.ts
+++ b/src/lib/server/shop/tickets/mutations.ts
@@ -1,4 +1,5 @@
 import type { TransactionClient } from "$lib/server/shop/types";
+import { convertPriceToCents } from "$lib/utils/convertPrice";
 import type { TicketSchema } from "$lib/utils/shop/types";
 import { PrismaClient, ShoppableType } from "@prisma/client";
 
@@ -19,7 +20,7 @@ export const createTicket = async (
             titleEn: data.titleEn,
             description: data.description,
             descriptionEn: data.descriptionEn,
-            price: Math.round(data.price * 100),
+            price: convertPriceToCents(data.price),
             availableFrom: data.availableFrom,
             availableTo: data.availableTo,
             type: ShoppableType.TICKET,
@@ -57,7 +58,7 @@ export const createTicket = async (
                     data: question.options.map((o) => ({
                       ...o,
                       extraPrice: o.extraPrice
-                        ? Math.round(o.extraPrice * 100)
+                        ? convertPriceToCents(o.extraPrice)
                         : o.extraPrice,
                     })),
                   },
@@ -91,7 +92,7 @@ export const updateTicket = async (
             titleEn: data.titleEn,
             description: data.description,
             descriptionEn: data.descriptionEn,
-            price: Math.round(data.price * 100),
+            price: convertPriceToCents(data.price),
             availableFrom: data.availableFrom,
             availableTo: data.availableTo,
             type: ShoppableType.TICKET,
@@ -197,7 +198,7 @@ const updateQuestions = async (
                   data: question.options.map((o) => ({
                     ...o,
                     extraPrice: o.extraPrice
-                      ? Math.round(o.extraPrice * 100)
+                      ? convertPriceToCents(o.extraPrice)
                       : o.extraPrice,
                   })),
                 },
@@ -222,7 +223,7 @@ const updateQuestions = async (
                     data: question.options.map((o) => ({
                       ...o,
                       extraPrice: o.extraPrice
-                        ? Math.round(o.extraPrice * 100)
+                        ? convertPriceToCents(o.extraPrice)
                         : o.extraPrice,
                     })),
                   },

--- a/src/lib/utils/convertPrice.test.ts
+++ b/src/lib/utils/convertPrice.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from "vitest";
+import { convertPriceToCents } from "./convertPrice";
+
+describe("helper.ts", () => {
+  describe("convertPriceToNumber", () => {
+    it("should convert price in kr to ören", () => {
+      expect(convertPriceToCents(123.45)).toBe(12345);
+      expect(convertPriceToCents(0)).toBe(0);
+      expect(convertPriceToCents(1.99)).toBe(199);
+      expect(convertPriceToCents(19.9)).toBe(1990);
+    });
+  });
+});

--- a/src/lib/utils/convertPrice.ts
+++ b/src/lib/utils/convertPrice.ts
@@ -1,0 +1,10 @@
+/**
+ * @param price in kr
+ * @returns price in ören
+ *
+ * @example
+ * convertPriceToCents(123.45) => 12345
+ */
+export const convertPriceToCents = (price: number) => {
+  return Math.round(price * 100);
+};

--- a/src/routes/(app)/expenses/upload/+page.server.ts
+++ b/src/routes/(app)/expenses/upload/+page.server.ts
@@ -20,6 +20,7 @@ import { expenseSchema } from "../types";
 import { sendNotificationToSigner } from "../helper";
 import { authorize } from "$lib/utils/authorization";
 import apiNames from "$lib/utils/apiNames";
+import { convertPriceToCents } from "$lib/utils/convertPrice";
 
 export const load = async ({ locals: { user } }) => {
   authorize(apiNames.EXPENSES.CREATE, user);
@@ -113,7 +114,7 @@ export const actions = {
             return {
               expenseId: expense.id,
               costCenter: row.costCenter,
-              amount: Math.floor(row.amount * 100), // convert to "öre"
+              amount: convertPriceToCents(row.amount),
               receiptUrl: uploadedReceipt,
               comment: row.comment,
               committeeShortName: costCenter.committee,


### PR DESCRIPTION
Multiplying floats caused floating-points arithmetic errors. For example, `19.9 * 100` evaluates to `1989.9999999999998`. Rounding solves that issue.

While I was at it, I updated price calculations to use a dedicated utility function for consistency and accuracy across the application. This change improves maintainability and ensures all price values are converted correctly.