### PR TITLE
Fix #768 booking calendar empty

### DIFF
--- a/src/routes/(app)/booking/+page.server.ts
+++ b/src/routes/(app)/booking/+page.server.ts
@@ -2,7 +2,7 @@ import { error } from "@sveltejs/kit";
 import dayjs from "dayjs";
 
 export const load = async (event) => {
-  const { prisma, user } = event.locals;
+  const { prisma } = event.locals;
   const bookables = await prisma.bookable.findMany();
   const bookingRequests = await prisma.bookingRequest.findMany({
     where: {

--- a/src/routes/(app)/booking/+page.server.ts
+++ b/src/routes/(app)/booking/+page.server.ts
@@ -6,13 +6,13 @@ export const load = async (event) => {
   const bookables = await prisma.bookable.findMany();
   const bookingRequests = await prisma.bookingRequest.findMany({
     where: {
-      bookerId: user.memberId,
       start: {
         gte: dayjs().subtract(1, "week").toDate(),
       },
     },
     orderBy: [{ start: "asc" }, { end: "asc" }, { status: "asc" }],
     include: {
+      booker: true,
       bookables: true,
     },
   });

--- a/src/routes/(app)/booking/+page.svelte
+++ b/src/routes/(app)/booking/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import type { PageData } from "./$types";
   import SetPageTitle from "$lib/components/nav/SetPageTitle.svelte";
   import * as m from "$paraglide/messages";
   import { isAuthorized } from "$lib/utils/authorization";
@@ -9,10 +10,14 @@
   import ConfirmDialog from "$lib/components/ConfirmDialog.svelte";
   import BookingCalendar from "./BookingCalendar.svelte";
 
-  export let data;
+  export let data: PageData;
   let deleteModal: HTMLDialogElement;
   let selectedBooking: (typeof data.bookingRequests)[number] | undefined =
     undefined;
+
+  let userBookings = data.bookingRequests.filter(
+    (v) => v.booker?.id === $page.data.member?.id,
+  );
 </script>
 
 <SetPageTitle title={m.bookings()} />
@@ -28,10 +33,9 @@
     </a>
   {/if}
 </div>
+<BookingCalendar {...data} />
 
-{#if data.bookingRequests.length === 0}
-  <BookingCalendar {...data} />
-{:else}
+{#if userBookings.length > 0}
   <div class="overflow-x-auto">
     <table class="table">
       <thead>
@@ -46,7 +50,7 @@
       </thead>
 
       <tbody>
-        {#each data.bookingRequests as bookingRequest (bookingRequest.id)}
+        {#each userBookings as bookingRequest (bookingRequest.id)}
           <tr>
             <td>
               {#each bookingRequest.bookables.map((a) => a.name) as bookable}
@@ -59,7 +63,7 @@
             <td>
               <StatusComponent
                 bind:bookingRequest
-                bind:bookingRequests={data.bookingRequests}
+                bind:bookingRequests={userBookings}
                 class="flex-col"
               />
             </td>


### PR DESCRIPTION
Fixed #768 by making sure the calendar always shows all bookings on the main booking page (at least as well as on the new booking page). Now the calendar will always show up even when the user has bookings registered. In that case, both the calendar and the booking list will show up.  