### PR TITLE
Implement Open Graph Protocol

### DIFF
--- a/src/lib/components/shop/cart/CartPage.svelte
+++ b/src/lib/components/shop/cart/CartPage.svelte
@@ -2,6 +2,7 @@
   import { invalidate } from "$app/navigation";
   import FoodPreferenceModal from "$lib/components/FoodPreferenceModal.svelte";
   import SetPageTitle from "$lib/components/nav/SetPageTitle.svelte";
+  import SEO from "$lib/seo/SEO.svelte";
   import type { CartLoadData } from "$lib/server/shop/cart/getCart";
   import { now } from "$lib/stores/date";
   import { superForm } from "$lib/utils/client/superForms";
@@ -26,6 +27,14 @@
 </script>
 
 <SetPageTitle title={m.cart()} />
+<SEO
+  data={{
+    type: "website",
+    props: {
+      title: m.cart(),
+    },
+  }}
+/>
 
 <FoodPreferenceModal />
 

--- a/src/lib/components/shop/inventory/InventoryItemPage.svelte
+++ b/src/lib/components/shop/inventory/InventoryItemPage.svelte
@@ -9,6 +9,7 @@
   import type { InventoryItemLoadData } from "$lib/server/shop/inventory/getInventory";
   import type { page } from "$app/stores";
   import { getFileUrl } from "$lib/files/client";
+  import SEO from "$lib/seo/SEO.svelte";
 
   export let data: InventoryItemLoadData & typeof $page.data;
   $: consumable = data.consumable;
@@ -17,6 +18,14 @@
 </script>
 
 <SetPageTitle title={shoppable.title} />
+<SEO
+  data={{
+    type: "website",
+    props: {
+      title: shoppable.title,
+    },
+  }}
+/>
 
 <div class="mx-auto md:container md:mt-8 md:grid md:grid-cols-2">
   <img

--- a/src/lib/components/shop/payments/CallbackPage.svelte
+++ b/src/lib/components/shop/payments/CallbackPage.svelte
@@ -2,6 +2,7 @@
   import { browser } from "$app/environment";
   import { invalidate } from "$app/navigation";
   import SetPageTitle from "$lib/components/nav/SetPageTitle.svelte";
+  import SEO from "$lib/seo/SEO.svelte";
   import { goto } from "$lib/utils/redirect";
   import * as m from "$paraglide/messages";
   import { onDestroy } from "svelte";
@@ -35,6 +36,14 @@
 </script>
 
 <SetPageTitle title={m.cart_paymentStatus_pageTitle()} />
+<SEO
+  data={{
+    type: "website",
+    props: {
+      title: m.cart_paymentStatus_pageTitle(),
+    },
+  }}
+/>
 
 <h1 class="text-xl font-semibold">{data.message}</h1>
 {#if interval}

--- a/src/lib/seo/SEO.svelte
+++ b/src/lib/seo/SEO.svelte
@@ -12,44 +12,6 @@
   let { image, data }: OpenGraphProps = $props();
 
   let actualImage = $state<ImageAttributes | null>(null);
-  if (image) actualImage = image;
-  else if (data.type === "article" && data.article.imageUrl) {
-    actualImage = {
-      url: data.article.imageUrl,
-      secure_url: data.article.imageUrl,
-      alt: data.article.header,
-      mime_type: "image/jpeg",
-      height: 1500,
-      width: 1500,
-    };
-  } else if (data.type === "profile" && data.member.picturePath) {
-    actualImage = {
-      url: data.member.picturePath,
-      secure_url: data.member.picturePath,
-      alt: `${data.member.firstName} ${data.member.lastName}`,
-      mime_type: "image/jpeg",
-      height: 1500,
-      width: 1500,
-    };
-  } else if (data.type === "committee" && data.committee.lightImageUrl) {
-    actualImage = {
-      url: data.committee.lightImageUrl,
-      secure_url: data.committee.lightImageUrl,
-      alt: data.committee.name,
-      mime_type: "image/svg+xml",
-      height: 1500,
-      width: 1500,
-    };
-  } else {
-    actualImage = {
-      url: getFileUrl("minio/photos/public/assets/guild-logo-full.svg"),
-      secure_url: getFileUrl("minio/photos/public/assets/guild-logo-full.svg"),
-      alt: "D-sektionen logo",
-      mime_type: "image/svg+xml",
-      height: 1500,
-      width: 1500,
-    };
-  }
 
   // https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/MIME_types#image_types
   type ImageMimeType =
@@ -175,6 +137,44 @@
     attributesProps = committeeToOpenGraphProps(data.committee);
   } else {
     attributesProps = websiteToOpenGraphProps(data.props);
+  }
+  if (image) actualImage = image;
+  else if (data.type === "article" && data.article.imageUrl) {
+    actualImage = {
+      url: data.article.imageUrl,
+      secure_url: data.article.imageUrl,
+      alt: data.article.header,
+      mime_type: "image/jpeg",
+      height: 1500,
+      width: 1500,
+    };
+  } else if (data.type === "profile" && data.member.picturePath) {
+    actualImage = {
+      url: data.member.picturePath,
+      secure_url: data.member.picturePath,
+      alt: `${data.member.firstName} ${data.member.lastName}`,
+      mime_type: "image/jpeg",
+      height: 1500,
+      width: 1500,
+    };
+  } else if (data.type === "committee" && data.committee.lightImageUrl) {
+    actualImage = {
+      url: data.committee.lightImageUrl,
+      secure_url: data.committee.lightImageUrl,
+      alt: data.committee.name,
+      mime_type: "image/svg+xml",
+      height: 1500,
+      width: 1500,
+    };
+  } else {
+    actualImage = {
+      url: getFileUrl("minio/photos/public/assets/guild-logo-full.svg"),
+      secure_url: getFileUrl("minio/photos/public/assets/guild-logo-full.svg"),
+      alt: "D-sektionen logo",
+      mime_type: "image/svg+xml",
+      height: 1500,
+      width: 1500,
+    };
   }
 </script>
 

--- a/src/lib/seo/SEO.svelte
+++ b/src/lib/seo/SEO.svelte
@@ -1,0 +1,149 @@
+<!-- 
+  This component adds metadata to a page for search engine optimization reasons.
+  It uses Open Graph protocol to define how the page should be represented on social media platforms.
+  https://ogp.me/
+-->
+
+<script lang="ts">
+  import { page } from "$app/state";
+  import type { Article, Member } from "@prisma/client";
+
+  // https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/MIME_types#image_types
+  type ImageMimeType =
+    | "image/apng"
+    | "image/avif"
+    | "image/gif"
+    | "image/jpeg"
+    | "image/png"
+    | "image/svg+xml"
+    | "image/webp";
+
+  type ArticleOpenGraphProps = Pick<
+    Article,
+    "header" | "body" | "publishedAt" | "updatedAt" | "imageUrl" | "slug"
+  > & {
+    authorName: string;
+  };
+
+  type MemberOpenGraphProps = Pick<
+    Member,
+    "firstName" | "lastName" | "studentId" | "picturePath" | "bio"
+  >;
+
+  type OpenGraphProps = {
+    data:
+      | {
+          type: "article";
+          article: ArticleOpenGraphProps;
+        }
+      | {
+          type: "profile";
+          member: MemberOpenGraphProps;
+        }
+      | {
+          type: "website";
+          props: {
+            title: string;
+            description?: string;
+          };
+        };
+
+    image?: {
+      url: string;
+      secure_url?: string;
+      alt: string;
+      mime_type: ImageMimeType;
+      height: number;
+      width: number;
+    };
+  };
+
+  let { image, data }: OpenGraphProps = $props();
+
+  let { locale, locale_alternate } = page.url.pathname.includes("/en")
+    ? { locale: "en_US", locale_alternate: ["se_SE"] }
+    : { locale: "se_SE", locale_alternate: ["en_US"] };
+
+  function articleToOpenGraphProps(article: ArticleOpenGraphProps) {
+    let props: Array<[string, string]> = [];
+    props.push(["og:type", "article"]);
+    props.push(["og:title", article.header]);
+    props.push(["og:description", article.body]);
+    props.push(["og:article:author", article.authorName]);
+    if (article.publishedAt) {
+      props.push(["article:published_time", article.publishedAt.toISOString()]);
+    }
+    if (article.updatedAt) {
+      props.push(["article:modified_time", article.updatedAt.toISOString()]);
+    }
+    if (article.imageUrl) {
+      props.push(["og:image", article.imageUrl]);
+    }
+    return props;
+  }
+
+  function profileToOpenGraphProps(member: MemberOpenGraphProps) {
+    let props: Array<[string, string]> = [];
+    props.push(["og:type", "profile"]);
+    props.push(["og:title", `${member.firstName} ${member.lastName}`]);
+    if (member.firstName) {
+      props.push(["profile:first_name", member.firstName]);
+    }
+    if (member.lastName) {
+      props.push(["profile:last_name", member.lastName]);
+    }
+    if (member.studentId) {
+      props.push(["profile:username", member.studentId]);
+    }
+    if (member.bio) {
+      props.push(["og:description", member.bio]);
+    }
+    if (member.picturePath) {
+      props.push(["og:image", member.picturePath]);
+    }
+    return props;
+  }
+
+  function websiteToOpenGraphProps(website: {
+    title: string;
+    description?: string;
+  }) {
+    let props: Array<[string, string]> = [];
+    props.push(["og:type", "website"]);
+    props.push(["og:title", website.title]);
+    if (website.description)
+      props.push(["og:description", website.description]);
+    if (image) props.push(["og:image", image.url]);
+    return props;
+  }
+
+  let attributesProps: Array<[string, string]> = $state([]);
+  if (data.type === "article") {
+    attributesProps = articleToOpenGraphProps(data.article);
+  } else if (data.type === "profile") {
+    attributesProps = profileToOpenGraphProps(data.member);
+  } else {
+    attributesProps = websiteToOpenGraphProps(data.props);
+  }
+</script>
+
+<svelte:head>
+  <meta property="og:site_name" content="D-sektionen" />
+  <meta property="og:locale" content={locale} />
+  {#each locale_alternate as loc}
+    <meta property="og:locale:alternate" content={loc} />
+  {/each}
+  <meta property="og:url" content={page.url.toString()} />
+  {#if image}
+    <meta property="og:image" content={image.url} />
+    <meta property="og:secure_url" content={image.secure_url} />
+    <meta property="og:image:width" content={image.width.toString()} />
+    <meta property="og:image:height" content={image.height.toString()} />
+    <meta property="og:image:alt" content={image.alt} />
+    <meta property="og:image:type" content={image.mime_type} />
+  {/if}
+
+  {#each attributesProps as [key, value]}
+    <meta property={key} content={value} />
+  {/each}
+</svelte:head>

--- a/src/routes/(app)/admin/access/+page.svelte
+++ b/src/routes/(app)/admin/access/+page.svelte
@@ -3,6 +3,7 @@
   import type { PageData } from "./$types";
   import * as m from "$paraglide/messages";
   import SetPageTitle from "$lib/components/nav/SetPageTitle.svelte";
+  import SEO from "$lib/seo/SEO.svelte";
   export let data: PageData;
   const { form, errors, constraints, enhance } = superForm(data.form, {
     resetForm: true,
@@ -10,6 +11,14 @@
 </script>
 
 <SetPageTitle title="Access policies" />
+<SEO
+  data={{
+    type: "website",
+    props: {
+      title: "Access policies",
+    },
+  }}
+/>
 
 <div class="overflow-x-auto">
   <table class="table">

--- a/src/routes/(app)/admin/access/[apiName]/+page.svelte
+++ b/src/routes/(app)/admin/access/[apiName]/+page.svelte
@@ -7,6 +7,7 @@
 
   import type { PageData } from "./$types";
   import SetPageTitle from "$lib/components/nav/SetPageTitle.svelte";
+  import SEO from "$lib/seo/SEO.svelte";
   export let data: PageData;
   const {
     form: createForm,
@@ -25,6 +26,14 @@
 </script>
 
 <SetPageTitle title={$page.params["apiName"]} />
+<SEO
+  data={{
+    type: "website",
+    props: {
+      title: $page.params["apiName"] ?? "",
+    },
+  }}
+/>
 
 <h1 class="mb-4 text-2xl font-semibold">{$page.params["apiName"]}</h1>
 <div class="overflow-x-auto">

--- a/src/routes/(app)/admin/alerts/+page.svelte
+++ b/src/routes/(app)/admin/alerts/+page.svelte
@@ -4,6 +4,7 @@
   import dayjs from "dayjs";
   import * as m from "$paraglide/messages";
   import SetPageTitle from "$lib/components/nav/SetPageTitle.svelte";
+  import SEO from "$lib/seo/SEO.svelte";
 
   export let data;
 
@@ -12,6 +13,14 @@
 </script>
 
 <SetPageTitle title="Alerts" />
+<SEO
+  data={{
+    type: "website",
+    props: {
+      title: "Alerts",
+    },
+  }}
+/>
 
 <form
   method="POST"

--- a/src/routes/(app)/admin/doors/+page.svelte
+++ b/src/routes/(app)/admin/doors/+page.svelte
@@ -5,10 +5,19 @@
   import type { PageData } from "./$types";
   import * as m from "$paraglide/messages";
   import SetPageTitle from "$lib/components/nav/SetPageTitle.svelte";
+  import SEO from "$lib/seo/SEO.svelte";
   export let data: PageData;
 </script>
 
 <SetPageTitle title="Doors" />
+<SEO
+  data={{
+    type: "website",
+    props: {
+      title: "Doors",
+    },
+  }}
+/>
 
 <div class="overflow-x-auto">
   <table class="table">

--- a/src/routes/(app)/admin/doors/edit/[slug]/+page.svelte
+++ b/src/routes/(app)/admin/doors/edit/[slug]/+page.svelte
@@ -6,6 +6,7 @@
 
   import type { PageData } from "./$types";
   import SetPageTitle from "$lib/components/nav/SetPageTitle.svelte";
+  import SEO from "$lib/seo/SEO.svelte";
   export let data: PageData;
   let type: "role" | "studentId" = "role";
 
@@ -23,6 +24,14 @@
 </script>
 
 <SetPageTitle title={$page.params["slug"]} />
+<SEO
+  data={{
+    type: "website",
+    props: {
+      title: $page.params["slug"] ?? "",
+    },
+  }}
+/>
 
 <main class="container mx-auto px-4">
   <h1 class="mb-4 text-2xl font-semibold capitalize">{$page.params["slug"]}</h1>

--- a/src/routes/(app)/app/account/+page.svelte
+++ b/src/routes/(app)/app/account/+page.svelte
@@ -6,10 +6,19 @@
   import { signIn, signOut } from "@auth/sveltekit/client";
   import DarkLightToggle from "../../../DarkLightToggle.svelte";
   import LanguageSwitcher from "../../../LanguageSwitcher.svelte";
+  import SEO from "$lib/seo/SEO.svelte";
   export let data;
 </script>
 
 <SetPageTitle title={m.account()} />
+<SEO
+  data={{
+    type: "website",
+    props: {
+      title: m.account(),
+    },
+  }}
+/>
 
 <div class="flex flex-1 flex-col gap-4 rounded-box bg-base-300 p-2">
   <ul class="menu gap-4 [&>li>a]:py-2">

--- a/src/routes/(app)/app/home/+page.svelte
+++ b/src/routes/(app)/app/home/+page.svelte
@@ -8,11 +8,31 @@
   import Documents from "$lib/components/home/Documents.svelte";
   import CodeWithDwww from "$lib/components/home/CodeWithDWWW.svelte";
   import AppHomeNavigation from "./AppHomeNavigation.svelte";
+  import SEO from "$lib/seo/SEO.svelte";
+  import * as m from "$paraglide/messages";
 
   export let data;
 </script>
 
+<!-- landing_intro -->
+
 <SetPageTitle title="D-sektionen" />
+<SEO
+  data={{
+    type: "website",
+    props: {
+      title: "D-sektionen",
+      description: m.landing_intro(),
+    },
+  }}
+  image={{
+    url: "https://raw.githubusercontent.com/Dsek-LTH/grafik/refs/heads/main/guild/d_sektionen/full/color.svg",
+    mime_type: "image/svg+xml",
+    width: 400,
+    height: 400,
+    alt: "D-sektionen logo",
+  }}
+/>
 
 <article class="flex flex-col gap-10">
   <section>

--- a/src/routes/(app)/app/home/+page.svelte
+++ b/src/routes/(app)/app/home/+page.svelte
@@ -25,13 +25,6 @@
       description: m.landing_intro(),
     },
   }}
-  image={{
-    url: "https://raw.githubusercontent.com/Dsek-LTH/grafik/refs/heads/main/guild/d_sektionen/full/color.svg",
-    mime_type: "image/svg+xml",
-    width: 400,
-    height: 400,
-    alt: "D-sektionen logo",
-  }}
 />
 
 <article class="flex flex-col gap-10">

--- a/src/routes/(app)/committees/CommitteePage.svelte
+++ b/src/routes/(app)/committees/CommitteePage.svelte
@@ -7,11 +7,28 @@
   import Pagination from "$lib/components/Pagination.svelte";
   import type { CommitteeLoadData } from "./committee.server";
   import type { page } from "$app/stores";
+  import SEO from "$lib/seo/SEO.svelte";
   export let data: CommitteeLoadData & typeof $page.data;
   export let isEditing = false;
   const thisYear = new Date().getFullYear();
 </script>
 
+<SEO
+  data={{
+    type: "website",
+    props: {
+      title: data.committee.name,
+      description: data.committee.description,
+    },
+  }}
+  image={{
+    url: data.committee.lightImageUrl,
+    alt: data.committee.name,
+    width: 1500,
+    height: 1500,
+    mime_type: "image/svg+xml",
+  }}
+></SEO>
 <CommitteeHeader
   committee={data.committee}
   uniqueMemberCount={data.uniqueMemberCount}

--- a/src/routes/(app)/home/+page.svelte
+++ b/src/routes/(app)/home/+page.svelte
@@ -26,13 +26,6 @@
       description: m.landing_intro(),
     },
   }}
-  image={{
-    url: "https://raw.githubusercontent.com/Dsek-LTH/grafik/refs/heads/main/guild/d_sektionen/full/color.svg",
-    mime_type: "image/svg+xml",
-    width: 400,
-    height: 400,
-    alt: "D-sektionen logo",
-  }}
 />
 
 <div class="grid grid-cols-1 gap-x-5 gap-y-10 md:grid-cols-3 xl:grid-cols-6">

--- a/src/routes/(app)/home/+page.svelte
+++ b/src/routes/(app)/home/+page.svelte
@@ -13,10 +13,27 @@
   import SetPageTitle from "$lib/components/nav/SetPageTitle.svelte";
   import * as m from "$paraglide/messages";
   import Readme from "$lib/components/home/Readme.svelte";
+  import OpenGraph from "$lib/seo/SEO.svelte";
   export let data: PageData;
 </script>
 
 <SetPageTitle />
+<OpenGraph
+  data={{
+    type: "website",
+    props: {
+      title: "D-sektionen",
+      description: m.landing_intro(),
+    },
+  }}
+  image={{
+    url: "https://raw.githubusercontent.com/Dsek-LTH/grafik/refs/heads/main/guild/d_sektionen/full/color.svg",
+    mime_type: "image/svg+xml",
+    width: 400,
+    height: 400,
+    alt: "D-sektionen logo",
+  }}
+/>
 
 <div class="grid grid-cols-1 gap-x-5 gap-y-10 md:grid-cols-3 xl:grid-cols-6">
   <section class="col-span-1 hidden flex-col place-items-center xl:flex">

--- a/src/routes/(app)/home/+page.svelte
+++ b/src/routes/(app)/home/+page.svelte
@@ -13,12 +13,12 @@
   import SetPageTitle from "$lib/components/nav/SetPageTitle.svelte";
   import * as m from "$paraglide/messages";
   import Readme from "$lib/components/home/Readme.svelte";
-  import OpenGraph from "$lib/seo/SEO.svelte";
+  import SEO from "$lib/seo/SEO.svelte";
   export let data: PageData;
 </script>
 
 <SetPageTitle />
-<OpenGraph
+<SEO
   data={{
     type: "website",
     props: {

--- a/src/routes/(app)/members/[studentId]/+page@(app).svelte
+++ b/src/routes/(app)/members/[studentId]/+page@(app).svelte
@@ -13,6 +13,7 @@
   import { languageTag } from "$paraglide/runtime";
   import PingButton from "./PingButton.svelte";
   import type { PageProps } from "./$types";
+  import SEO from "$lib/seo/SEO.svelte";
 
   let { data }: PageProps = $props();
 
@@ -50,6 +51,13 @@
 </script>
 
 <SetPageTitle title={member ? getFullName(member) : "Medlem"} />
+
+<SEO
+  data={{
+    type: "profile",
+    member,
+  }}
+/>
 
 <figure
   class="hero-gradient hero-gradient-{member.classProgramme ??

--- a/src/routes/(app)/news/+page.svelte
+++ b/src/routes/(app)/news/+page.svelte
@@ -29,13 +29,6 @@
       description: m.landing_intro(),
     },
   }}
-  image={{
-    url: "https://raw.githubusercontent.com/Dsek-LTH/grafik/refs/heads/main/guild/d_sektionen/full/color.svg",
-    mime_type: "image/svg+xml",
-    width: 400,
-    height: 400,
-    alt: "D-sektionen logo",
-  }}
 />
 
 <div class="space-y-4">

--- a/src/routes/(app)/news/+page.svelte
+++ b/src/routes/(app)/news/+page.svelte
@@ -12,6 +12,7 @@
 
   import type { PageData } from "./$types";
   import SetPageTitle from "$lib/components/nav/SetPageTitle.svelte";
+  import SEO from "$lib/seo/SEO.svelte";
   let filteredTags: Tag[] = data.allTags.filter((tag) =>
     $page.url.searchParams.getAll("tags").includes(tag.name),
   );
@@ -20,6 +21,22 @@
 </script>
 
 <SetPageTitle title={m.news()} />
+<SEO
+  data={{
+    type: "website",
+    props: {
+      title: "D-sektionen",
+      description: m.landing_intro(),
+    },
+  }}
+  image={{
+    url: "https://raw.githubusercontent.com/Dsek-LTH/grafik/refs/heads/main/guild/d_sektionen/full/color.svg",
+    mime_type: "image/svg+xml",
+    width: 400,
+    height: 400,
+    alt: "D-sektionen logo",
+  }}
+/>
 
 <div class="space-y-4">
   <section>

--- a/src/routes/(app)/news/[slug]/+page.svelte
+++ b/src/routes/(app)/news/[slug]/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { enhance } from "$app/forms";
-  import OpenGraph from "$lib/seo/SEO.svelte";
+  import SEO from "$lib/seo/SEO.svelte";
   import LoadingButton from "$lib/components/LoadingButton.svelte";
   import TagChip from "$lib/components/TagChip.svelte";
   import SetPageTitle from "$lib/components/nav/SetPageTitle.svelte";
@@ -21,7 +21,7 @@
 
 <SetPageTitle title={article.header} />
 
-<OpenGraph
+<SEO
   data={{
     type: "article",
     article: {

--- a/src/routes/(app)/news/[slug]/+page.svelte
+++ b/src/routes/(app)/news/[slug]/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { enhance } from "$app/forms";
+  import OpenGraph from "$lib/seo/SEO.svelte";
   import LoadingButton from "$lib/components/LoadingButton.svelte";
   import TagChip from "$lib/components/TagChip.svelte";
   import SetPageTitle from "$lib/components/nav/SetPageTitle.svelte";
@@ -19,6 +20,16 @@
 </script>
 
 <SetPageTitle title={article.header} />
+
+<OpenGraph
+  data={{
+    type: "article",
+    article: {
+      ...article,
+      authorName: `${author.member.firstName} ${author.member.lastName}`,
+    },
+  }}
+/>
 
 <article>
   <Article {article}>

--- a/src/routes/(app)/search/+page.svelte
+++ b/src/routes/(app)/search/+page.svelte
@@ -8,6 +8,7 @@
   } from "$lib/search/searchTypes";
   import { mapIndexToMessage } from "$lib/search/searchHelpers";
   import { isSearchResultData } from "$lib/components/search/SearchUtils";
+  import OpenGraph from "$lib/seo/SEO.svelte";
 
   let formElement: HTMLFormElement;
   let inputElement: HTMLInputElement;
@@ -124,6 +125,23 @@
 </script>
 
 <svelte:window on:keydown={onKeyDown} />
+
+<OpenGraph
+  data={{
+    type: "website",
+    props: {
+      title: "D-sektionen",
+      description: m.landing_intro(),
+    },
+  }}
+  image={{
+    url: "https://raw.githubusercontent.com/Dsek-LTH/grafik/refs/heads/main/guild/d_sektionen/full/color.svg",
+    mime_type: "image/svg+xml",
+    width: 400,
+    height: 400,
+    alt: "D-sektionen logo",
+  }}
+/>
 
 <form
   method="POST"

--- a/src/routes/(app)/search/+page.svelte
+++ b/src/routes/(app)/search/+page.svelte
@@ -134,13 +134,6 @@
       description: m.landing_intro(),
     },
   }}
-  image={{
-    url: "https://raw.githubusercontent.com/Dsek-LTH/grafik/refs/heads/main/guild/d_sektionen/full/color.svg",
-    mime_type: "image/svg+xml",
-    width: 400,
-    height: 400,
-    alt: "D-sektionen logo",
-  }}
 />
 
 <form

--- a/src/routes/(app)/search/+page.svelte
+++ b/src/routes/(app)/search/+page.svelte
@@ -8,7 +8,7 @@
   } from "$lib/search/searchTypes";
   import { mapIndexToMessage } from "$lib/search/searchHelpers";
   import { isSearchResultData } from "$lib/components/search/SearchUtils";
-  import OpenGraph from "$lib/seo/SEO.svelte";
+  import SEO from "$lib/seo/SEO.svelte";
 
   let formElement: HTMLFormElement;
   let inputElement: HTMLInputElement;
@@ -126,7 +126,7 @@
 
 <svelte:window on:keydown={onKeyDown} />
 
-<OpenGraph
+<SEO
   data={{
     type: "website",
     props: {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -6,6 +6,7 @@
   import { page } from "$app/stores";
   import { languageTag } from "$paraglide/runtime";
   import { invalidateAll } from "$app/navigation";
+  import SEO from "$lib/seo/SEO.svelte";
 
   let carouselEls: HTMLDivElement[] = [];
 
@@ -116,6 +117,16 @@
     },
   ] as const;
 </script>
+
+<SEO
+  data={{
+    type: "website",
+    props: {
+      title: "D-sektionen",
+      description: m.landing_intro(),
+    },
+  }}
+/>
 
 <!-- svelte-ignore a11y_consider_explicit_label -->
 <div class="drawer drawer-end">


### PR DESCRIPTION
Closes #775 

This adds the metadata to many pages. Some pages don't really need SEO, so they are omitted (such as the debug pages).

Unfortunately, I think we need to add this component manually every time. I tried having a default, fallback value in the root `+layout.svelte`, but if I wanted to override it on a specific page, the metadata tags just get duplicated.