### PR TITLE
Only accept PDFs for expenses.

### DIFF
--- a/src/routes/(app)/expenses/upload/ExpenseReceipt.svelte
+++ b/src/routes/(app)/expenses/upload/ExpenseReceipt.svelte
@@ -64,7 +64,7 @@
     label={m.receipt()}
     field={`receipts[${index}].image`}
     onChange={(e) => onFileSelected(e)}
-    accept="image/png,image/jpeg,application/pdf"
+    accept="application/pdf"
     multiple
   />
   {#if receiptPhotos !== undefined}


### PR DESCRIPTION
Only allows PDF files to be attached to expenses, the only way to get the final expense PDFs to always play nice when its time to send them to bookkeeping.