### PR TITLE
Add default classYear to onboarding

### DIFF
--- a/src/lib/utils/member.ts
+++ b/src/lib/utils/member.ts
@@ -200,6 +200,7 @@ export const createMember = async (
     return await prisma.member.create({
       data: {
         ...data,
+        classYear: new Date().getFullYear(),
         subscriptionSettings: {
           createMany: {
             data: NOLLA_DEFAULT_SUBSCRIPTION_SETTINGS,
@@ -219,6 +220,7 @@ export const createMember = async (
   return await prisma.member.create({
     data: {
       ...data,
+      classYear: new Date().getFullYear(),
       subscriptionSettings: {
         createMany: {
           data: DEFAULT_SUBSCRIPTION_SETTINGS,

--- a/src/routes/(app)/onboarding/+page.server.ts
+++ b/src/routes/(app)/onboarding/+page.server.ts
@@ -36,7 +36,11 @@ export const load: PageServerLoad = async ({ locals }) => {
   const phadderGroups = phadderGroupsResult.value;
   return {
     form: await superValidate(
-      { ...member, classProgramme: member.classProgramme ?? "D" },
+      {
+        ...member,
+        classProgramme: member.classProgramme ?? "D",
+        classYear: member.classYear ?? new Date().getFullYear(),
+      },
       zod(memberSchema),
     ),
     member,


### PR DESCRIPTION
Set the default classYear to the current year during member creation and loading to avoid user confusion.