### PR TITLE
Defer rendering of members in phadder groups

### DIFF
--- a/src/lib/components/socials/MembersList.svelte
+++ b/src/lib/components/socials/MembersList.svelte
@@ -2,27 +2,47 @@
   import AuthorSignature from "$lib/components/socials/AuthorSignature.svelte";
   import type { Member } from "@prisma/client";
 
-  let modal: HTMLDialogElement;
+  let modal: HTMLDialogElement | null;
   export let members: Member[];
 
   let clazz: string | undefined = undefined;
   export { clazz as class };
+
+  let open = false;
+  $: {
+    if (open) modal?.showModal();
+  }
 </script>
 
 {#if members.length > 0}
-  <button on:click|preventDefault={() => modal.showModal()} class={clazz}>
+  <button
+    on:click|preventDefault={() => {
+      open = true;
+    }}
+    class={clazz}
+  >
     <slot />
   </button>
-  <dialog id="members_modal" class="modal" bind:this={modal}>
-    <ul class="modal-box m-1 flex flex-col">
-      {#each members as liker (liker.id)}
-        <li>
-          <AuthorSignature type="member" lazy member={liker} />
-        </li>
-      {/each}
-    </ul>
-    <form method="dialog" class="modal-backdrop">
-      <button>close</button>
-    </form>
+  <dialog
+    id="members_modal"
+    class="modal"
+    bind:this={modal}
+    on:close={() => (open = false)}
+    on:click={(e) => {
+      if (e.target === modal) modal?.close();
+    }}
+  >
+    {#if open}
+      <ul class="modal-box m-1 flex flex-col">
+        {#each members as liker (liker.id)}
+          <li>
+            <AuthorSignature type="member" lazy member={liker} />
+          </li>
+        {/each}
+      </ul>
+      <form method="dialog" class="modal-backdrop">
+        <button>close</button>
+      </form>
+    {/if}
   </dialog>
 {/if}

--- a/src/lib/components/socials/MembersList.svelte
+++ b/src/lib/components/socials/MembersList.svelte
@@ -1,34 +1,40 @@
 <script lang="ts">
   import AuthorSignature from "$lib/components/socials/AuthorSignature.svelte";
   import type { Member } from "@prisma/client";
+  import type { Snippet } from "svelte";
 
-  let modal: HTMLDialogElement | null;
-  export let members: Member[];
+  let modal: HTMLDialogElement | undefined = $state();
 
-  let clazz: string | undefined = undefined;
-  export { clazz as class };
-
-  let open = false;
-  $: {
-    if (open) modal?.showModal();
+  interface Props {
+    members: Member[];
+    class?: string | undefined;
+    children?: Snippet;
   }
+
+  let { members, class: clazz = undefined, children }: Props = $props();
+
+  let open = $state(false);
+  $effect(() => {
+    if (modal) modal.showModal();
+  });
 </script>
 
 {#if members.length > 0}
   <button
-    on:click|preventDefault={() => {
+    onclick={(event) => {
+      event.preventDefault();
       open = true;
     }}
     class={clazz}
   >
-    <slot />
+    {@render children?.()}
   </button>
   <dialog
     id="members_modal"
     class="modal"
     bind:this={modal}
-    on:close={() => (open = false)}
-    on:click={(e) => {
+    onclose={() => (open = false)}
+    onclick={(e) => {
       if (e.target === modal) modal?.close();
     }}
   >


### PR DESCRIPTION
Prevent crashes on Safari by deferring the rendering of members in phadder groups. Update the MembersList component to Svelte 5 syntax.