### PR TITLE
fix: svelte elements error

### DIFF
--- a/src/database/seed/data.ts
+++ b/src/database/seed/data.ts
@@ -1,5 +1,5 @@
 import { fakerSV as faker } from "@faker-js/faker";
-import { type SeedClientOptions } from "@snaplet/seed";
+import type { SeedClientOptions } from "@snaplet/seed";
 import dayjs from "dayjs";
 import apiNames from "$lib/utils/apiNames";
 import * as positionEnums from "$lib/utils/committee-ordering/enums";

--- a/src/lib/components/forms/FormSelect.svelte
+++ b/src/lib/components/forms/FormSelect.svelte
@@ -16,7 +16,7 @@
     type SuperForm,
   } from "sveltekit-superforms";
   import { twMerge } from "tailwind-merge";
-  import { type HTMLSelectAttributes } from "svelte/elements";
+  import type { HTMLSelectAttributes } from "svelte/elements";
 
   let {
     superform,

--- a/src/lib/components/forms/FormSubmitButton.svelte
+++ b/src/lib/components/forms/FormSubmitButton.svelte
@@ -5,7 +5,7 @@
 <script lang="ts" generics="T extends Record<string, unknown>">
   import LoadingButton from "$lib/components/LoadingButton.svelte";
 
-  import { type SuperForm } from "sveltekit-superforms";
+  import type { SuperForm } from "sveltekit-superforms";
 
   export let superform: SuperForm<T>;
   let clazz: string | undefined = undefined;

--- a/src/lib/components/member/SubscriptionTags.svelte
+++ b/src/lib/components/member/SubscriptionTags.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { type Tag } from "@prisma/client";
+  import type { Tag } from "@prisma/client";
 
   export let subscribedTags: Tag[];
   export let tags: Tag[];

--- a/src/lib/components/shop/MaxAmountPerUser.svelte
+++ b/src/lib/components/shop/MaxAmountPerUser.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import FormNumberInput from "$lib/components/forms/FormNumberInput.svelte";
   import type { TicketSchema } from "$lib/utils/shop/types";
-  import { type SuperForm } from "sveltekit-superforms/client";
+  import type { SuperForm } from "sveltekit-superforms/client";
 
   export let superform: SuperForm<TicketSchema>;
 </script>

--- a/src/lib/utils/adminSettings/nollning.ts
+++ b/src/lib/utils/adminSettings/nollning.ts
@@ -1,5 +1,5 @@
 import authorizedPrismaClient from "$lib/server/authorizedPrisma";
-import { type PrismaClient } from "@prisma/client";
+import type { PrismaClient } from "@prisma/client";
 
 export const NOLLNING_START_KEY = "nollning_start";
 export const NOLLNING_END_KEY = "nollning_end";

--- a/src/routes/(app)/admin/links/+page.server.ts
+++ b/src/routes/(app)/admin/links/+page.server.ts
@@ -1,6 +1,6 @@
 import type { PageServerLoad } from "./$types";
 import { ShlinkApiClient } from "@shlinkio/shlink-js-sdk";
-import { type ProblemDetailsError } from "@shlinkio/shlink-js-sdk/api-contract";
+import type { ProblemDetailsError } from "@shlinkio/shlink-js-sdk/api-contract";
 import { env } from "$env/dynamic/private";
 import { NodeHttpClient } from "@shlinkio/shlink-js-sdk/node";
 import { error, fail, type Actions, type NumericRange } from "@sveltejs/kit";

--- a/src/routes/(app)/booking/BookingEditor.svelte
+++ b/src/routes/(app)/booking/BookingEditor.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { type Infer, type SuperValidated } from "sveltekit-superforms";
+  import type { Infer, SuperValidated } from "sveltekit-superforms";
   import type { BookingSchema } from "./schema";
   import { superForm } from "$lib/utils/client/superForms";
   import * as m from "$paraglide/messages";

--- a/src/routes/(app)/committees/nollu/groups/PhadderGroupForm.svelte
+++ b/src/routes/(app)/committees/nollu/groups/PhadderGroupForm.svelte
@@ -4,7 +4,7 @@
   import FormSubmitButton from "$lib/components/forms/FormSubmitButton.svelte";
   import type { PhadderGroupSchema } from "$lib/nollning/groups/types";
   import { superForm } from "$lib/utils/client/superForms";
-  import { type FormOptions, type SuperValidated } from "sveltekit-superforms";
+  import type { FormOptions, SuperValidated } from "sveltekit-superforms";
 
   export let create = false;
   type Schema = Omit<PhadderGroupSchema, "id"> | PhadderGroupSchema;

--- a/src/routes/(app)/committees/types.ts
+++ b/src/routes/(app)/committees/types.ts
@@ -1,4 +1,4 @@
-import { type Infer } from "sveltekit-superforms/server";
+import type { Infer } from "sveltekit-superforms/server";
 import { z } from "zod";
 
 export const updateSchema = z.object({

--- a/src/routes/(app)/events/EventEditor.svelte
+++ b/src/routes/(app)/events/EventEditor.svelte
@@ -7,7 +7,7 @@
   import Labeled from "$lib/components/Labeled.svelte";
   import TagChip from "$lib/components/TagChip.svelte";
   import TagSelector from "$lib/components/TagSelector.svelte";
-  import { type EventSchema } from "$lib/events/schema";
+  import type { EventSchema } from "$lib/events/schema";
   import { superForm } from "$lib/utils/client/superForms";
   import { recurringTypes } from "$lib/utils/events";
   import * as m from "$paraglide/messages";

--- a/src/routes/(app)/expenses/all/+page.server.ts
+++ b/src/routes/(app)/expenses/all/+page.server.ts
@@ -1,4 +1,4 @@
-import { type Actions } from "@sveltejs/kit";
+import type { Actions } from "@sveltejs/kit";
 import { expensesInclusion } from "../getExpenses";
 import type { Prisma } from "@prisma/client";
 import {

--- a/src/routes/(app)/expenses/types.ts
+++ b/src/routes/(app)/expenses/types.ts
@@ -1,5 +1,5 @@
 import { isFileImage, isFilePDF } from "$lib/files/utils";
-import { type Infer } from "sveltekit-superforms";
+import type { Infer } from "sveltekit-superforms";
 import { z } from "zod";
 import { isValidCostCenter } from "./config";
 

--- a/src/routes/(app)/expenses/upload/ExpenseReceiptRow.svelte
+++ b/src/routes/(app)/expenses/upload/ExpenseReceiptRow.svelte
@@ -2,7 +2,7 @@
   import FormInput from "$lib/components/forms/FormInput.svelte";
   import FormNumberInput from "$lib/components/forms/FormNumberInput.svelte";
   import FormSelect from "$lib/components/forms/FormSelect.svelte";
-  import { type SuperForm } from "sveltekit-superforms";
+  import type { SuperForm } from "sveltekit-superforms";
   import { COST_CENTERS } from "../config";
   import type { ExpenseSchema } from "../types";
   import * as m from "$paraglide/messages";

--- a/src/routes/(app)/medals/+page.server.ts
+++ b/src/routes/(app)/medals/+page.server.ts
@@ -1,5 +1,5 @@
 import type { PageServerLoad } from "./$types";
-import { type Semester } from "$lib/utils/semesters";
+import type { Semester } from "$lib/utils/semesters";
 import { medalRecipients } from "$lib/server/medals/medals";
 import { getSemesterOrThrowSvelteError } from "$lib/utils/url.server";
 

--- a/src/routes/(app)/members/[studentId]/profile-picture/types.ts
+++ b/src/routes/(app)/members/[studentId]/profile-picture/types.ts
@@ -1,5 +1,5 @@
 import * as m from "$paraglide/messages";
-import { type Infer } from "sveltekit-superforms/server";
+import type { Infer } from "sveltekit-superforms/server";
 import { z } from "zod";
 
 export const changeSchema = z.object({

--- a/src/routes/(app)/news/ArticleForm.svelte
+++ b/src/routes/(app)/news/ArticleForm.svelte
@@ -10,7 +10,7 @@
   import type { ArticleSchema } from "$lib/news/schema";
   import * as m from "$paraglide/messages";
   import type { Tag } from "@prisma/client";
-  import { type SuperForm } from "sveltekit-superforms";
+  import type { SuperForm } from "sveltekit-superforms";
 
   export let authorOptions: AuthorOption[];
   export let allTags: Tag[];


### PR DESCRIPTION
Sometimes we are getting this error when running `pnpm dev`
```
✘ [ERROR] No known conditions for "./elements" specifier in "svelte" package [plugin vite:dep-scan]

    script:/home/isak/dwww/web/src/lib/components/forms/FormSelect.svelte?id=1:44:7:
      44 │ import "svelte/elements"
```
fix: https://johnnyreilly.com/typescript-5-importsnotusedasvalues-error-eslint-consistent-type-imports#no-import-type-side-effects