### PR TITLE
Create kubernetes yaml for podman dev

### DIFF
--- a/podman-dev.yaml
+++ b/podman-dev.yaml
@@ -8,52 +8,52 @@ metadata:
   name: dsekweb-services
 spec:
   containers:
-  - name: db
-    image: docker.io/library/postgres:16-alpine
-    env:
-    - name: POSTGRES_DB
-      value: dsek
-    - name: POSTGRES_USER
-      value: postgres
-    - name: POSTGRES_PASSWORD
-      value: postgres
-    ports:
-    - containerPort: 5432
-      hostPort: 5432
-    volumeMounts:
-    - mountPath: /var/lib/postgresql/data
-      name: db-pvc
+    - name: db
+      image: docker.io/library/postgres:16-alpine
+      env:
+        - name: POSTGRES_DB
+          value: dsek
+        - name: POSTGRES_USER
+          value: postgres
+        - name: POSTGRES_PASSWORD
+          value: postgres
+      ports:
+        - containerPort: 5432
+          hostPort: 5432
+      volumeMounts:
+        - mountPath: /var/lib/postgresql/data
+          name: db-pvc
 
-  - name: meilisearch
-    image: docker.io/getmeili/meilisearch:latest
-    env:
-    - name: MEILI_MASTER_KEY
-      value: masterKey
-    - name: MEILI_NO_ANALYTICS
-      value: "true"
-    ports:
-    - containerPort: 7700
-      hostPort: 7700
-    volumeMounts:
-    - mountPath: /data.ms
-      name: meilisearch-pvc
+    - name: meilisearch
+      image: docker.io/getmeili/meilisearch:latest
+      env:
+        - name: MEILI_MASTER_KEY
+          value: masterKey
+        - name: MEILI_NO_ANALYTICS
+          value: "true"
+      ports:
+        - containerPort: 7700
+          hostPort: 7700
+      volumeMounts:
+        - mountPath: /data.ms
+          name: meilisearch-pvc
 
-  - name: poppler-server
-    image: poppler-server
-    env:
-    - name: PORT
-      value: "8800"
-    ports:
-    - containerPort: 8800
-      hostPort: 8800
+    - name: poppler-server
+      image: poppler-server
+      env:
+        - name: PORT
+          value: "8800"
+      ports:
+        - containerPort: 8800
+          hostPort: 8800
 
   volumes:
-  - name: db-pvc
-    persistentVolumeClaim:
-      claimName: db
-  - name: meilisearch-pvc
-    persistentVolumeClaim:
-      claimName: meilisearch
+    - name: db-pvc
+      persistentVolumeClaim:
+        claimName: db
+    - name: meilisearch-pvc
+      persistentVolumeClaim:
+        claimName: meilisearch
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -63,7 +63,7 @@ metadata:
   name: db
 spec:
   accessModes:
-  - ReadWriteOnce
+    - ReadWriteOnce
   resources:
     requests:
       storage: 1Gi
@@ -76,7 +76,7 @@ metadata:
   name: meilisearch
 spec:
   accessModes:
-  - ReadWriteOnce
+    - ReadWriteOnce
   resources:
     requests:
       storage: 1Gi

--- a/podman-dev.yaml
+++ b/podman-dev.yaml
@@ -1,0 +1,82 @@
+# Use with `podman kube play`
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: dsekweb-services
+  name: dsekweb-services
+spec:
+  containers:
+  - name: db
+    image: docker.io/library/postgres:16-alpine
+    env:
+    - name: POSTGRES_DB
+      value: dsek
+    - name: POSTGRES_USER
+      value: postgres
+    - name: POSTGRES_PASSWORD
+      value: postgres
+    ports:
+    - containerPort: 5432
+      hostPort: 5432
+    volumeMounts:
+    - mountPath: /var/lib/postgresql/data
+      name: db-pvc
+
+  - name: meilisearch
+    image: docker.io/getmeili/meilisearch:latest
+    env:
+    - name: MEILI_MASTER_KEY
+      value: masterKey
+    - name: MEILI_NO_ANALYTICS
+      value: "true"
+    ports:
+    - containerPort: 7700
+      hostPort: 7700
+    volumeMounts:
+    - mountPath: /data.ms
+      name: meilisearch-pvc
+
+  - name: poppler-server
+    image: poppler-server
+    env:
+    - name: PORT
+      value: "8800"
+    ports:
+    - containerPort: 8800
+      hostPort: 8800
+
+  volumes:
+  - name: db-pvc
+    persistentVolumeClaim:
+      claimName: db
+  - name: meilisearch-pvc
+    persistentVolumeClaim:
+      claimName: meilisearch
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  annotations:
+    volume.podman.io/driver: local
+  name: db
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  annotations:
+    volume.podman.io/driver: local
+  name: meilisearch
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi


### PR DESCRIPTION
`podman-dev.yaml` serves the same purpose as `docker-compose.yml`, but instead of using the compose format, it uses kubernetes YAML supported natively by podman.

## How to test

Usage is same as with docker, except instead of `docker compose up -d`, run `podman kube play podman-dev.yaml` (on podman version <=4.2, the command is `podman play kube podman-dev.yaml`).