### PR TITLE
Fix language switching on home page

### DIFF
--- a/src/lib/server/loadHomeData.ts
+++ b/src/lib/server/loadHomeData.ts
@@ -117,9 +117,9 @@ export const loadHomeData = async ({
   });
 
   // COMMIT DATA
-  const commitPromise = fetch("/api/home").then((res) =>
-    res.json(),
-  ) as Promise<GetCommitDataResponse>;
+  const commitPromise = fetch(
+    `${locals.language === "en" ? "/en" : ""}/api/home`,
+  ).then((res) => res.json()) as Promise<GetCommitDataResponse>;
 
   // RANDOM WELLBEING MESSAGE
   const wellbeing_random_sentence = [


### PR DESCRIPTION
When fetching the commit data on the home page, `databaseHandle` in hooks runs for a second time and overrides the language set on the prisma client extension. This causes data to be fetched in swedish regardless of the users language setting. 

This PR fixes this by prepending the language tag to the api fetch, which avoids any incorrect hook runs.