### PR TITLE
install pnpm via npm in poppler dockerfile

### DIFF
--- a/poppler-server/Dockerfile
+++ b/poppler-server/Dockerfile
@@ -1,5 +1,5 @@
 # Use a lightweight Node.js image
-FROM node:25-alpine
+FROM node:24-alpine
 ENV NODE_ENV=production
 
 # Install pdftotext (from poppler-utils)


### PR DESCRIPTION
Newest node versions no longer bundle corepack so this build broke 😢 