### PR TITLE
Add in-progress webhook sending on news creation

### DIFF
--- a/src/lib/news/server/actions.ts
+++ b/src/lib/news/server/actions.ts
@@ -69,6 +69,17 @@ const sendNewArticleNotification = async (
   });
 };
 
+const limitDescription = (text: string): string => {
+  let description = text.replace("\n", " ").slice(0, 256 - 3);
+  description += description.length == 256 - 3 ? "..." : "";
+
+  const rows = description.split("\n");
+  if (rows.length > 4) {
+    description = rows.slice(0, 4).join("\n") + "...";
+  }
+  return description;
+};
+
 const sendNewArticleWebhook = async (
   article: ExtendedPrismaModel<"Article"> & {
     tags: Array<Pick<ExtendedPrismaModel<"Tag">, "id">>;
@@ -76,6 +87,36 @@ const sendNewArticleWebhook = async (
   },
   notificationText: string | null | undefined,
 ) => {
+  const member = await authorizedPrismaClient.member.findUnique({
+    where: {
+      id: article.author.memberId,
+    },
+  });
+  const tags = await authorizedPrismaClient.tag.findMany({
+    where: {
+      id: {
+        in: article.tags.map((tag) => tag.id),
+      },
+    },
+  });
+
+  let title: string | undefined = undefined;
+  if (article.author.mandateId !== null) {
+    const mandate = await authorizedPrismaClient.mandate.findUnique({
+      where: {
+        id: article.author.mandateId ?? undefined,
+      },
+    });
+    if (mandate) {
+      const position = await authorizedPrismaClient.position.findUnique({
+        where: {
+          id: mandate?.positionId,
+        },
+      });
+      title = position?.nameSv;
+    }
+  }
+
   // Create an object mapping key -> value of the following
   // keys. Removes potential duplicates (if possible)
   const settings = Object.fromEntries(
@@ -83,12 +124,7 @@ const sendNewArticleWebhook = async (
       await authorizedPrismaClient.adminSetting.findMany({
         where: {
           key: {
-            in: [
-              "discord_webhook_se",
-              "discord_webhook_en",
-              "webhook_tags_se",
-              "webhook_tags_en",
-            ],
+            in: ["discord_webhook_se", "webhook_tags_se"],
           },
         },
         select: {
@@ -99,43 +135,66 @@ const sendNewArticleWebhook = async (
     ).map((row) => [row.key, row.value]),
   );
 
-  if (!settings["discord_webhook"]) return; // No webhook to call
+  if (!settings["discord_webhook_se"]) return; // No webhook to call
 
   // If webhook_tags is not set, we allow through all news
-  if (settings["webhook_tags"]) {
-    const webhookTags = new Set(settings["webhook_tags"].split(","));
+  if (settings["webhook_tags_se"]) {
+    const webhookTags = new Set(settings["webhook_tags_se"].split(","));
 
     // Otherwise, webhook_tags acts as a filter. Only allow articles that
-    // have any of the tags
+    // have any of the tags. We assume that the article has very few tags
     if (!article.tags.some((tag) => webhookTags.has(tag.id))) return;
   }
 
   // In most cases, an event will only have one tag. For the others,
-  // we just pick an arbitrary tag until we have a priority...
-  let color = null
+  // we just pick an arbitrary tag
+  let color = undefined;
+  let footer = undefined;
   if (article.tags.length > 0) {
-    // TODO: Figure out which structure tag color has?..
-    color = tags.find(tag => tag.id === article.tags[0]?.id)?.color
+    const tag = tags.find((tag) => tag.id === article.tags[0]?.id);
+    if (tag !== undefined) {
+      footer = tag.nameSv;
+    }
+
+    if (typeof tag?.color === "string") {
+      // Convert HEX-string in the form #FFFFFF to an integer for Discord API
+      color = parseInt(tag.color.slice(1), 16);
+    }
   }
 
-  await fetch(settings["discord_webhook"], {
+  // Limit news description to first few characters as a preview, although
+  // you could technically fit the entire article within the 4096 character limit
+  let description = limitDescription(article.bodySv);
+
+  const body = {
+    content: notificationText,
+    embeds: [
+      {
+        title: article.headerSv,
+        author: {
+          name: `${member?.firstName} ${member?.lastName} ${title ? "| " + title : ""}`,
+          icon_url: member?.picturePath,
+        },
+        // Default to development URL
+        url: `${process.env["ORIGIN"] ?? "http://localhost:5173"}/news/${article.slug}`,
+        description: description,
+        color: color,
+        footer: {
+          text: footer,
+        },
+        timestamp: article.createdAt,
+      },
+    ],
+  };
+
+  const res = await fetch(settings["discord_webhook_se"], {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      content: notificationText,
-      embeds: [
-        {
-          title: article.headerSv,
-          author: {
-            name: `${member?.firstName} "${member?.nickname}" ${member?.lastName}`,
-            icon_url: member?.picturePath,
-          },
-          url: `${process.env["ORIGIN"]}/news/${article.slug}`,
-          
-        }
-      ]
-    }),
+    body: JSON.stringify(body),
   });
+  if (res.status != 204) {
+    console.log(`notifications: failed Discord webhook (${res.status})`);
+  }
 };
 
 export const createArticle: Action = async (event) => {


### PR DESCRIPTION
This pull request will add cross-sending news to Discord. Using webhooks, each article that passes a filter, will be sent as an embed in a given channel. This will fix the issue in Rosa Pantern: https://github.com/Dsek-LTH/rasa-pantern/issues/6.

Currently a draft to give a small update, non-working apart from some early tests.