### PR TITLE
Prefer non-relative import suggestions in TypeScript

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -32,4 +32,5 @@
     "**/pnpm-lock.yaml": true,
   },
   "typescript.preferences.importModuleSpecifierEnding": "minimal",
+  "typescript.preferences.importModuleSpecifier": "non-relative"
 }


### PR DESCRIPTION
Update TypeScript preferences to suggest non-relative import module specifiers for improved code clarity.