### PR TITLE
fix broken link on article card

### DIFF
--- a/src/lib/components/ArticleCard.svelte
+++ b/src/lib/components/ArticleCard.svelte
@@ -44,7 +44,7 @@
       ></div>
     {:else}
       <div
-        style="background-image: url(https://raw.githubusercontent.com/Dsek-LTH/grafik/refs/heads/main/guild/d_sektionen/full/color.svg);"
+        style="background-image: url(https://raw.githubusercontent.com/Dsek-LTH/grafik/refs/heads/main/guild/dsek/color.svg);"
         class="aspect-[2/1] w-full shrink-0 rounded-md bg-[#eee] bg-size-[30%] bg-center bg-no-repeat"
       ></div>
     {/if}


### PR DESCRIPTION
### 🧩 Summary

<!-- What does this PR do? -->
Fixes the broken link to the grafik repo, which removed the guild logo from the Article card.

### 🔗 Related issues (if any)

Closes #

### 📸 Screenshots / recordings (if applicable)

<!-- Before / after, UX flow changes, etc. -->

### 💬 Other information

<!-- Anything else reviewers should know? -->
