### PR TITLE
Remove article body from share

### DIFF
--- a/src/routes/(app)/news/[slug]/+page.svelte
+++ b/src/routes/(app)/news/[slug]/+page.svelte
@@ -22,7 +22,6 @@
   async function share() {
     const shareData = {
       title: article?.header ?? "<title missing>",
-      text: article?.body ?? "<body missing>",
       url: window.location.href,
     };
 


### PR DESCRIPTION
### 🧩 Summary

Removes the article body (markdown dump) from share. This provides a better user experience.

### 🔗 Related issues (if any)

None

### 📸 Screenshots / recordings (if applicable)
Before:
<img width="1170" height="2532" alt="image" src="https://github.com/user-attachments/assets/97674196-87d8-4419-94be-49a55317edad" />

After:
<img width="1170" height="2532" alt="image" src="https://github.com/user-attachments/assets/c3469db5-da7d-483b-90a5-6f61f623b541" />


### 💬 Other information

None
