### PR TITLE
New design: Fix committee positions

### DIFF
--- a/src/routes/(app)/committees/(single)/[shortName]/members/+page.svelte
+++ b/src/routes/(app)/committees/(single)/[shortName]/members/+page.svelte
@@ -6,10 +6,8 @@
 
   let { data }: { data: CommitteeLoadData } = $props();
 
-  let leftRow = $derived(data.committee.positions.filter((_, i) => i % 2 == 0));
-  let rightRow = $derived(
-    data.committee.positions.filter((_, i) => i % 2 == 1),
-  );
+  let leftRow = $derived(data.positions.filter((_, i) => i % 2 == 0));
+  let rightRow = $derived(data.positions.filter((_, i) => i % 2 == 1));
 </script>
 
 <h2>{m.committees_members()}</h2>


### PR DESCRIPTION
fixes the position ordering in `/committees/[shortName]/members`