### PR TITLE
sort SRD meetings correctly

### DIFF
--- a/src/routes/(app)/documents/+page.svelte
+++ b/src/routes/(app)/documents/+page.svelte
@@ -34,11 +34,26 @@
       value: "other",
     },
   ];
-  $: meetings = Object.keys(data.meetings).sort((a, b) =>
+  $: meetings = Object.keys(data.meetings).sort((a, b) => {
+    if (type === "board-meeting") {
+      return b.localeCompare(a, "sv");
+    } else if (type === "SRD-meeting" && a.startsWith("SRD")) {
+      return (
+        // Current format
+        Number.parseInt(b.split("SRD")[1] ?? "0") -
+        Number.parseInt(a.split("SRD")[1] ?? "0")
+      );
+    } else if (type === "SRD-meeting") {
+      return ("T" + a).localeCompare(b, "sv"); // Sort other SRD meetings below current format
+    } else {
+      return a.localeCompare(b, "sv");
+    }
+  });
+  /*
     type === "board-meeting" || type === "SRD-meeting"
       ? b.localeCompare(a, "sv")
       : a.localeCompare(b, "sv"),
-  );
+  );*/
   $: canCreate = isAuthorized(
     apiNames.FILES.BUCKET(PUBLIC_BUCKETS_DOCUMENTS).CREATE,
     data.user,

--- a/src/routes/(app)/documents/+page.svelte
+++ b/src/routes/(app)/documents/+page.svelte
@@ -49,11 +49,6 @@
       return a.localeCompare(b, "sv");
     }
   });
-  /*
-    type === "board-meeting" || type === "SRD-meeting"
-      ? b.localeCompare(a, "sv")
-      : a.localeCompare(b, "sv"),
-  );*/
   $: canCreate = isAuthorized(
     apiNames.FILES.BUCKET(PUBLIC_BUCKETS_DOCUMENTS).CREATE,
     data.user,


### PR DESCRIPTION
### 🧩 Summary
Sorts the new SRD meeting format correctly:

Before: SRD1, SRD10, SRD8, SRD9
After: SRD1, SRD8, SRD9, SRD10
<!-- What does this PR do? -->

### 🔗 Related issues (if any)


### 📸 Screenshots / recordings (if applicable)

<!-- Before / after, UX flow changes, etc. -->

### 💬 Other information

<!-- Anything else reviewers should know? -->
