### PR TITLE
spin out documentTypes into enum

### DIFF
--- a/src/routes/(app)/documents/+page.server.ts
+++ b/src/routes/(app)/documents/+page.server.ts
@@ -15,7 +15,7 @@ import { z } from "zod";
 import type { Actions, PageServerLoad } from "./$types";
 import * as m from "$paraglide/messages";
 import { getYearOrThrowSvelteError } from "$lib/utils/url.server";
-import { documentTypes, documentTypes as dt } from "./types";
+import { DocumentTypes as dt } from "./types";
 
 const validDocumentTypes = [
   dt.boardMeeting,
@@ -25,7 +25,7 @@ const validDocumentTypes = [
 ] as const;
 export type DocumentType = (typeof validDocumentTypes)[number];
 
-const prefixByType: Record<documentTypes, string> = {
+const prefixByType: Record<dt, string> = {
   [dt.boardMeeting]: "S",
   [dt.guildMeeting]: "",
   [dt.SRDMeeting]: "Möte ",

--- a/src/routes/(app)/documents/+page.server.ts
+++ b/src/routes/(app)/documents/+page.server.ts
@@ -15,26 +15,27 @@ import { z } from "zod";
 import type { Actions, PageServerLoad } from "./$types";
 import * as m from "$paraglide/messages";
 import { getYearOrThrowSvelteError } from "$lib/utils/url.server";
+import { documentTypes, documentTypes as dt } from "./types";
 
 const validDocumentTypes = [
-  "board-meeting",
-  "guild-meeting",
-  "SRD-meeting",
-  "other",
+  dt.boardMeeting,
+  dt.guildMeeting,
+  dt.SRDMeeting,
+  dt.other,
 ] as const;
 export type DocumentType = (typeof validDocumentTypes)[number];
 
-const prefixByType: Record<DocumentType, string> = {
-  "board-meeting": "S",
-  "guild-meeting": "",
-  "SRD-meeting": "Möte ",
-  other: "",
+const prefixByType: Record<documentTypes, string> = {
+  [dt.boardMeeting]: "S",
+  [dt.guildMeeting]: "",
+  [dt.SRDMeeting]: "Möte ",
+  [dt.other]: "",
 };
 export const load: PageServerLoad = async ({ locals, url }) => {
   const { user } = locals;
   const year = getYearOrThrowSvelteError(url);
 
-  const type = url.searchParams.get("type") || "board-meeting";
+  const type = url.searchParams.get("type") || dt.boardMeeting;
   if (!isValidDocumentType(type)) {
     throw error(400, m.documents_errors_invalidType());
   }
@@ -60,7 +61,7 @@ export const load: PageServerLoad = async ({ locals, url }) => {
   let filteredFiles = files;
   const oldFormatSRDFiles: FileData[] = [];
   switch (type) {
-    case "guild-meeting":
+    case dt.guildMeeting:
       filteredFiles = files.filter((file) => {
         const fileParts = file.id.split("/");
         const meeting =
@@ -69,7 +70,7 @@ export const load: PageServerLoad = async ({ locals, url }) => {
       });
       break;
 
-    case "SRD-meeting":
+    case dt.SRDMeeting:
       SRDfiles.forEach((file) => {
         const fileParts = file.id.split("/");
         const meetingName =
@@ -84,7 +85,7 @@ export const load: PageServerLoad = async ({ locals, url }) => {
       });
       break;
 
-    case "other":
+    case dt.other:
       filteredFiles = files.filter((file) => {
         const fileParts = file.id.split("/");
         const meeting =

--- a/src/routes/(app)/documents/+page.svelte
+++ b/src/routes/(app)/documents/+page.svelte
@@ -11,39 +11,40 @@
   import type { PageData } from "./$types";
   import SetPageTitle from "$lib/components/nav/SetPageTitle.svelte";
   export let data: PageData;
+  import { documentTypes, documentTypes as dt } from "./types";
 
   let isEditing = false;
 
   const currentYear = new Date().getFullYear();
-  let type: DocumentType = "board-meeting";
+  let type: documentTypes = dt.boardMeeting;
   const typeOptions: Array<{ name: string; value: DocumentType }> = [
     {
       name: m.documents_guildMeetings(),
-      value: "guild-meeting",
+      value: dt.guildMeeting,
     },
     {
       name: m.documents_boardMeetings(),
-      value: "board-meeting",
+      value: dt.boardMeeting,
     },
     {
       name: m.documents_srdMeetings(),
-      value: "SRD-meeting",
+      value: dt.SRDMeeting,
     },
     {
       name: m.documents_other(),
-      value: "other",
+      value: dt.other,
     },
   ];
   $: meetings = Object.keys(data.meetings).sort((a, b) => {
-    if (type === "board-meeting") {
+    if (type === dt.boardMeeting) {
       return b.localeCompare(a, "sv");
-    } else if (type === "SRD-meeting" && a.startsWith("SRD")) {
+    } else if (type === dt.SRDMeeting && a.startsWith("SRD")) {
       return (
         // Current format
         Number.parseInt(b.split("SRD")[1] ?? "0") -
         Number.parseInt(a.split("SRD")[1] ?? "0")
       );
-    } else if (type === "SRD-meeting") {
+    } else if (type === dt.SRDMeeting) {
       return ("T" + a).localeCompare(b, "sv"); // Sort other SRD meetings below current format
     } else {
       return a.localeCompare(b, "sv");

--- a/src/routes/(app)/documents/+page.svelte
+++ b/src/routes/(app)/documents/+page.svelte
@@ -11,12 +11,12 @@
   import type { PageData } from "./$types";
   import SetPageTitle from "$lib/components/nav/SetPageTitle.svelte";
   export let data: PageData;
-  import { documentTypes, documentTypes as dt } from "./types";
+  import { DocumentTypes as dt } from "./types";
 
   let isEditing = false;
 
   const currentYear = new Date().getFullYear();
-  let type: documentTypes = dt.boardMeeting;
+  let type: dt = dt.boardMeeting;
   const typeOptions: Array<{ name: string; value: DocumentType }> = [
     {
       name: m.documents_guildMeetings(),

--- a/src/routes/(app)/documents/types.ts
+++ b/src/routes/(app)/documents/types.ts
@@ -1,0 +1,6 @@
+export enum documentTypes {
+  boardMeeting = "board-meeting",
+  guildMeeting = "guild-meeting",
+  SRDMeeting = "SRD-meeting",
+  other = "other",
+}

--- a/src/routes/(app)/documents/types.ts
+++ b/src/routes/(app)/documents/types.ts
@@ -1,4 +1,4 @@
-export enum documentTypes {
+export enum DocumentTypes {
   boardMeeting = "board-meeting",
   guildMeeting = "guild-meeting",
   SRDMeeting = "SRD-meeting",


### PR DESCRIPTION
### 🧩 Summary
This changes a bunch of hard-coded strings to be an enum to remove chance of misspellings, and allow for auto tab completion with LSP or similar.