### PR TITLE
Add union governing documents link to ours

### DIFF
--- a/src/routes/(app)/documents/governing/+page.svelte
+++ b/src/routes/(app)/documents/governing/+page.svelte
@@ -60,6 +60,15 @@
       styrelsen@dsek.se
     </a>
   </p>
+  <p>
+    {m.documents_governing_not_finding_intro()}
+    <a
+      href="https://www.tlth.se/styrdokument"
+      class="link link-primary no-underline hover:underline"
+    >
+      {m.documents_governing_union_governing_documents()}
+    </a>{m.documents_governing_not_finding_outro()}
+  </p>
   <div class="flex max-w-28 items-center gap-5">
     <FileWithDownload
       name={m.documents_governing_statutes()}

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -920,5 +920,8 @@
   "cafe_error_sign_off_close": "Not permitted to abandon a shift so close in time. If you need to, contact the Vice Head of the Cafe.",
   "cafe_error_sign_off_after": "Not permitted to abandon an already completed shift.",
   "cafe_error_sign_on_after": "You can't sign up for a shift that's already happened.",
-  "cafe_closed": "Closed"
+  "cafe_closed": "Closed",
+  "documents_governing_not_finding_intro": "Not finding what you're looking for? Keep in mind that our governing documents are subordinate to the ",
+  "documents_governing_union_governing_documents": "governing documents of the Union",
+  "documents_governing_not_finding_outro": ". Perhaps you might find what you seek there?"
 }

--- a/src/translations/sv.json
+++ b/src/translations/sv.json
@@ -917,5 +917,8 @@
   "cafe_error_sign_off_close": "Du har inte tillåtelse att avanmäla dig så tätt inpå. Om du måste, kontaka Vice Cafémästare.",
   "cafe_error_sign_off_after": "Du har inte tillåtelse att avanmäla dig från avklarade skift.",
   "cafe_error_sign_on_after": "Du kan inte anmäla dig till ett pass som redan hänt.",
-  "cafe_closed": "Stängt"
+  "cafe_closed": "Stängt",
+  "documents_governing_not_finding_intro": "Hittar du inte vad du söker? Kom ihåg att våra styrdokument är underordnade ",
+  "documents_governing_union_governing_documents": "Kårens styrdokument",
+  "documents_governing_not_finding_outro": ". Kanske hittar du det du letar efter där?"
 }


### PR DESCRIPTION
This adds another small paragraph in the governing document preamble about the fact that our governing documents are subordinate to those of the Union, and therefore adds a link there in case the sought information is to be found there.