### PR TITLE
General access fixes

### DIFF
--- a/src/database/schema.zmodel
+++ b/src/database/schema.zmodel
@@ -632,7 +632,7 @@ model Member {
   classYear               Int?                    @map("class_year")
   graduationYear          Int?                    @map("graduation_year")
   visible                 Boolean                 @default(true)
-  foodPreference          String?                 @map("food_preference") @db.VarChar(255)
+  foodPreference          String?                 @map("food_preference") @db.VarChar(255) @allow("read", (auth().memberId == id) || (has(auth().policies, "webshop:manage")) || has(auth().policies, "core:member:update"))
   language                String?                 @map("language") @db.VarChar(255)
   stripeCustomerId        String?                 @map("stripe_customer_id")
 
@@ -1287,11 +1287,11 @@ model Readme {
 }
 
 model CafeShift {
-  id            String      @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
-  date          DateTime
-  workerId      String      @db.Uuid
-  worker        Member      @relation(fields: [workerId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "worker_id_foreign")
-  timeSlot      TimeSlot    @map("time_slot")
+  id       String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  date     DateTime
+  workerId String   @db.Uuid
+  worker   Member   @relation(fields: [workerId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "worker_id_foreign")
+  timeSlot TimeSlot @map("time_slot")
 
   @@map("cafe_shifts")
   @@allow("read", true)
@@ -1334,18 +1334,18 @@ enum TimeSlot {
 }
 
 model CiabattaOfTheWeek {
-    id          String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
-    year        Int
-    week        Int
-    name        String
+  id   String @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  year Int
+  week Int
+  name String
 
-    @@map("ciabatta_of_the_week")
-    @@allow("read", true)
+  @@map("ciabatta_of_the_week")
+  @@allow("read", true)
 
-    @@allow("create", has(auth().policies, "cafe:edit_ciabattas"))
+  @@allow("create", has(auth().policies, "cafe:edit_ciabattas"))
 
-    @@allow("update", has(auth().policies, "cafe:edit_ciabattas"))
+  @@allow("update", has(auth().policies, "cafe:edit_ciabattas"))
 
-    @@allow("delete", has(auth().policies, "cafe:edit_ciabattas"))
-    @@unique([year, week], map: "week_year_unique")
+  @@allow("delete", has(auth().policies, "cafe:edit_ciabattas"))
+  @@unique([year, week], map: "week_year_unique")
 }

--- a/src/lib/utils/adminSettings/nollning.ts
+++ b/src/lib/utils/adminSettings/nollning.ts
@@ -7,7 +7,14 @@ let cache: {
   value: boolean;
   lastFetched: Date;
 } | null = null;
+
+let startCache: {
+  value: Date;
+  lastFetched: Date;
+} | null = null;
+
 const CACHE_TIME = 3600 * 1000; // 1 hour
+
 export const isNollningPeriod = async () => {
   const now = new Date();
   if (
@@ -38,6 +45,30 @@ export const isNollningPeriod = async () => {
     lastFetched: now,
   };
   return isNollningPeriod;
+};
+
+export const getNollningStart = async () => {
+  const now = new Date();
+  if (
+    startCache !== null &&
+    startCache.lastFetched.valueOf() + CACHE_TIME > now.valueOf()
+  )
+    return startCache.value;
+  const row = await authorizedPrismaClient.adminSetting.findUnique({
+    where: {
+      key: NOLLNING_START_KEY,
+    },
+  });
+  const startStr = row?.value;
+  if (!startStr) {
+    return null;
+  }
+  const start = new Date(startStr);
+  startCache = {
+    value: start,
+    lastFetched: now,
+  };
+  return start;
 };
 
 export const updateNollningPeriod = async (

--- a/src/routes/(app)/admin/access/+page.server.ts
+++ b/src/routes/(app)/admin/access/+page.server.ts
@@ -9,7 +9,7 @@ import * as m from "$paraglide/messages";
 
 export const load: PageServerLoad = async ({ locals }) => {
   const { prisma, user } = locals;
-  authorize(apiNames.ACCESS_POLICY.READ, user);
+  authorize(apiNames.ACCESS_POLICY.UPDATE, user);
 
   const accessPolicies = await prisma.accessPolicy.findMany().then((policies) =>
     policies

--- a/src/routes/(app)/admin/access/[apiName]/+page.server.ts
+++ b/src/routes/(app)/admin/access/[apiName]/+page.server.ts
@@ -33,7 +33,7 @@ export type DeleteSchema = Infer<typeof deleteSchema>;
 
 export const load: PageServerLoad = async ({ locals, params }) => {
   const { prisma, user } = locals;
-  authorize(apiNames.ACCESS_POLICY.READ, user);
+  authorize(apiNames.ACCESS_POLICY.UPDATE, user);
 
   const policies = await prisma.accessPolicy.findMany({
     where: {

--- a/src/routes/(app)/admin/access/positions/+page.server.ts
+++ b/src/routes/(app)/admin/access/positions/+page.server.ts
@@ -2,6 +2,8 @@ import { fail, superValidate } from "sveltekit-superforms";
 import type { Actions, PageServerLoad } from "./$types";
 import { z } from "zod";
 import { zod } from "sveltekit-superforms/adapters";
+import apiNames from "$lib/utils/apiNames";
+import { authorize } from "$lib/utils/authorization";
 
 const deletePolicySchema = z.object({ policyId: z.string() });
 const createPolicySchema = z.object({
@@ -11,7 +13,10 @@ const createPolicySchema = z.object({
 });
 
 export const load: PageServerLoad = async ({ locals }) => {
-  const { prisma } = locals;
+  const { prisma, user } = locals;
+
+  authorize(apiNames.ACCESS_POLICY.UPDATE, user);
+
   const accesspolicies = await prisma.accessPolicy.findMany({
     select: { role: true, apiName: true, id: true },
   });

--- a/src/routes/(app)/admin/info/+page.server.ts
+++ b/src/routes/(app)/admin/info/+page.server.ts
@@ -6,10 +6,15 @@ import { infoPageSchema } from "./schemas";
 import type { Actions, PageServerLoad } from "./$types";
 import * as m from "$paraglide/messages";
 import { slugify } from "$lib/utils/slugify";
+import { authorize } from "$lib/utils/authorization";
+import apiNames from "$lib/utils/apiNames";
 
-export const load: PageServerLoad = async () => ({
-  form: await superValidate(zod(infoPageSchema)),
-});
+export const load: PageServerLoad = async ({ locals }) => {
+  const { user } = locals;
+  authorize(apiNames.MARKDOWN.CREATE, user);
+
+  return { form: await superValidate(zod(infoPageSchema)) };
+};
 
 export const actions: Actions = {
   create: async (event) => {

--- a/src/routes/(app)/admin/minio/+page.server.ts
+++ b/src/routes/(app)/admin/minio/+page.server.ts
@@ -4,6 +4,8 @@ import { PUBLIC_BUCKETS_FILES } from "$env/static/public";
 import { fileHandler } from "$lib/files";
 import { getFileUrl } from "$lib/files/client";
 import { uploadFile } from "$lib/files/uploadFiles";
+import apiNames from "$lib/utils/apiNames";
+import { authorize } from "$lib/utils/authorization";
 import * as m from "$paraglide/messages";
 import { fail, message, superValidate, withFiles } from "sveltekit-superforms";
 import { zod } from "sveltekit-superforms/adapters";
@@ -14,6 +16,8 @@ const MISCELLANEOUS_FILES_PREFIX = `public/miscellaneous`;
 
 export const load = async ({ locals }) => {
   const { user } = locals;
+
+  authorize(apiNames.FILES.BUCKET(PUBLIC_BUCKETS_FILES).CREATE, user);
 
   // access is checked in the fileHandler
   const files = await fileHandler

--- a/src/routes/(app)/admin/qr/+page.server.ts
+++ b/src/routes/(app)/admin/qr/+page.server.ts
@@ -6,7 +6,7 @@ import type { PageServerLoad } from "./$types";
 
 export const load: PageServerLoad = async ({ locals, url }) => {
   const { prisma, user } = locals;
-  authorize(apiNames.EVENT.READ, user);
+  authorize(apiNames.WEBSHOP.CONSUME, user);
 
   // Get page number from URL query params (default to 1)
   const page = parseInt(url.searchParams.get("page") || "1");

--- a/src/routes/(app)/gallery/+page.server.ts
+++ b/src/routes/(app)/gallery/+page.server.ts
@@ -1,7 +1,13 @@
 import { PUBLIC_BUCKETS_ALBUMS } from "$env/static/public";
 import { fileHandler } from "$lib/files";
 import type { FileData } from "$lib/files/fileHandler";
+import {
+  getNollningStart,
+  isNollningPeriod,
+} from "$lib/utils/adminSettings/nollning";
+import { isAuthorized } from "$lib/utils/authorization";
 import type { PageServerLoad } from "./$types";
+import apiNames from "$lib/utils/apiNames";
 
 export const load: PageServerLoad = async ({ locals }) => {
   const { user } = locals;
@@ -24,7 +30,18 @@ export const load: PageServerLoad = async ({ locals }) => {
     {},
   );
 
-  const albumEntries = Object.entries(filesGroupedByAlbum);
+  let albumEntries = Object.entries(filesGroupedByAlbum);
+  const nollningPeriod = await isNollningPeriod();
+  const nollningStart = await getNollningStart();
+
+  if (nollningPeriod && !isAuthorized(apiNames.MEMBER.SEE_STABEN, user)) {
+    albumEntries = albumEntries.filter(
+      (a) =>
+        Date.parse(a[0].split(" ")[0]!) >
+        (nollningStart ?? new Date(0)).getTime(),
+    );
+  }
+
   return {
     albums: albumEntries,
   };

--- a/src/routes/(app)/privacy-policy/+page.svelte
+++ b/src/routes/(app)/privacy-policy/+page.svelte
@@ -214,7 +214,7 @@ följande:
 
 Förfrågan om att verkställa ovan nämnda rättigheter ska besvaras inom en
 månad. Begäran görs genom kontakt direkt med styrelsen via e-post:
-styrelsen@dsek.se
+[styrelsen@dsek.se](mailto:styrelsen@dsek.se)
 
 # Cookies
 
@@ -223,7 +223,7 @@ standardinformation om internetloggar och besökares beteende. Vid besök
 på våra webbplatser kan vi komma att automatiskt samla in information
 från genom cookies eller liknande teknik.
 
-För mer information, besök allaboutcookies.org.
+För mer information, besök [allaboutcookies.org](https://allaboutcookies.org).
 
 ## Hur använder vi cookies?
 
@@ -270,14 +270,14 @@ insamling, lagring och hantering på rätt sätt.
 Vid frågor om D-sektionens policy för hantering av personuppgifter, den
 data vi har samlat in om dig eller om utövandet av ovan nämnda
 dataskyddsrättigheter kan styrelsen kontaktas på följande e-postadress:
-styrelsen@dsek.se
+[styrelsen@dsek.se](mailto:styrelsen@dsek.se)
 
 ## Hur lämpliga myndigheter kontaktas
 
 Vid rapportering av klagomål gällande hantering av personuppgifter eller
 kring ärenden som relaterar till personuppgiftshantering kan
 Integritetsskyddsmyndigheten kontaktas på följande e-postadress:
-imy@imy.se
+[imy@imy.se](mailto:imy@imy.se)
 `;
 </script>
 

--- a/src/routes/(app)/privacy-policy/+page.svelte
+++ b/src/routes/(app)/privacy-policy/+page.svelte
@@ -1,100 +1,284 @@
-<article>
-  <h1 class="text-center text-4xl">
-    Policy för hantering av personuppgifter (Privacy Policy)
-  </h1>
-  <h2 class="text-2xl">1 Formalia</h2>
-  <section class="pl-2">
-    <h3 class="text-xl">1.1 Sammanfattning</h3>
-    Policy för hantering av personuppgifter beskriver hur sektionen skall hantera
-    personuppgifter och vilken bakgrund som finns i olika situationer.
-    <h3 class="text-xl">1.2 Syfte</h3>
-    Denna policy har tagits fram för att säkerställa att D-sektionen följer GDPR
-    samt att underlätta för funktionärer att hantera personuppgifter på ett korrekt
-    sätt.
-    <h3 class="text-xl">1.3 Omfattning</h3>
-    Sektionen i sin helhet.
-    <h3 class="text-xl">1.4 Historik</h3>
-    Policyn är antagen på styrelsemöte S24 2018. Uppdaterad enl. Policy för Policyer
-    på HTM2 2021. Uppdaterad enl. Policy för styrdokument på VTM-extra 2023. Policyn
-    updaterades VTM-extra 2023 av Rafael Holgersson.
-  </section>
+<script lang="ts">
+  import MarkdownBody from "$lib/components/MarkdownBody.svelte";
 
-  <h2 class="text-2xl">2 Insamling av personuppgifter</h2>
+  const policy = `
+# Policy för hantering av personuppgifter
 
-  <section class="pl-2">
-    <h3 class="text-xl">2.1 Insamling</h3>
-    D-sektionens utskott kan inför evenemang eller i andra sektionsrelaterade fall
-    behöva samla in och förvara personuppgifter internt för att evenemanget ska kunna
-    genomföras på ett smidigt sätt. Exempel på tillfällen kan vara:
-    <ul class="list-disc pl-5">
-      <li>Sittning eller annan fest</li>
-      <li>Lunchföreläsning, Casekväll eller liknande</li>
-      <li>Idrottsevenemang</li>
-    </ul>
-    Syftet med att samla in personuppgifter inför ett evenemang, vem som har tillgång
-    till dessa samt under vilken tidsperiod de lagras ska tydliggöras i Sektionens
-    registerförteckning. Samma information skall också tydligt framgå för personen
-    som skall lämna sina uppgifter. Exempel på personuppgifter som kan sparas tillfälligt:
-    <ul class="list-disc pl-5">
-      <li>För- och efternamn</li>
-      <li>Årskurs</li>
-      <li>Matpreferens</li>
-      <li>E-postadress</li>
-      <li>Telefonnummer</li>
-    </ul>
-    Insamlingen av personuppgifter kan ske genom utskick av formulär eller i samband
-    med betalning/anmälningslänk.
+## Sammanfattning
 
-    <h3 class="text-xl">2.2 Samtycke</h3>
-    I samband med att personuppgifterna hämtas skall godkännande från personen i
-    fråga också hämtas. Samtycke måste lämnas aktivt och tydligt samt skall sparas
-    tills dess att uppgifterna raderas. Samtycke kan ges muntligt om detta dokumenteras
-    på tillfredsställande vis. Om personen inte godkänner att dennes personuppgifter
-    sparas ska Sektionen ej spara dessa. Det är funktionären som samlade in uppgifterna
-    som ansvarar för att vid samma tillfälle också samla in samtycke. Det ska vara
-    tydligt framgå vad som sparas och till vilket syfte.
-  </section>
+Policy för hantering av personuppgifter beskriver hur sektionen skall
+hantera personuppgifter och vilken bakgrund som finns i olika
+situationer.
 
-  <h2 class="text-2xl">3 Lagring av personuppgifter</h2>
-  Personuppgifter som tillfälligt samlas in lagras på konton kopplade till Sektionens
-  Googlekonton. Uppgifterna lagras tills dess att evenemanget är genomfört och det
-  inte längre finns något syfte att spara dem.
-  <section class="pl-2">
-    <h3 class="text-xl">3.1 Tillgänglighet</h3>
-    Vid behov kan andra funktionärer ges tillgång till de insamlade personuppgifterna
-    i ställföreträdande syfte eller som extra bemanning. Den ansvariga funktionären
-    ska kunna redogör vem som har haft tillgång till systemet, i vilket syfte och
-    under vilken tidsperiod.
-  </section>
+## Syfte
 
-  <h2 class="text-2xl">4 Hantering</h2>
-  De insamlade uppgifterna hanteras av funktionären som är ansvarig över evenemanget
-  och som samlade in uppgifterna. Ordförande för berört utskott är ansvarig för att
-  funktionären hanterar uppgifterna enligt policyn. Personuppgifter från det tillfälliga
-  registret kan endast begäras ut av personen i fråga under förutsättningen att den
-  kan identifiera sig med godkänd ID-handling. I övrigt kan endast personuppgifter
-  lämnas ut till andra parter på skriftligt beslut från Styrelsen. Styrelsen är skyldig
-  att informera personen ifråga innan personuppgifterna lämnas ut.
-  <section class="pl-2">
-    <h3 class="text-xl">4.1 Spridning</h3>
-    Funktionären som samlar in personuppgifterna är ansvarig för att uppgifterna
-    inte sprids eller missbrukas på något sätt. Vid dataintrång eller annat missbruk
-    skall personen vars uppgifter utnyttjats underrättas om situationen direkt. Styrelsen
-    är ansvarig för att berörda parter underrättas vid dataintrång/spridning/missbruk.
+Denna policy har tagits fram för att säkerställa att D-sektionen följer
+GDPR samt att underlätta för funktionärer att hantera personuppgifter på
+ett korrekt sätt.
 
-    <h3 class="text-xl">4.2 Radering</h3>
-    När man samlar in godkännande för lagringen av personuppgifter ska också ett
-    datum anges där personuppgifterna kommer raderas. Detta datumet ska vara efter
-    potentiellt evenemang eller då de inte längre kommer användas. Exempel kan vara
-    efter ett val, eller i slutet av året när ens funktionärer har fått sitt tack.
-    Om radering ej är möjlig ska uppgifterna anonymiseras. Funktionären som samlat
-    in personuppgifterna är ansvarig för radering/anonymisering.
-  </section>
+## Omfattning
 
-  <h2 class="text-2xl">5 Ansvar</h2>
-  D-sektionen och dess företrädare (d.v.s styrelsen) är ytterst ansvarig för att
-  insamling, lagring samt hantering av personuppgifter sker på korrekt sätt enligt
-  lag och sektionens antagna bestämmelser. Respektive utskottsordförande är ansvarig
-  för att medlemmarna inom utskottet sköter insamling, lagring och hantering på rätt
-  sätt.
-</article>
+Sektionen i sin helhet.
+
+## Historik
+
+Policyn är antagen på styrelsemöte S24 2018. Uppdaterad enl. Policy för
+Policyer på HTM2 2021. Uppdaterad enl. Policy för styrdokument på
+VTM-extra 2023. Policyn updaterades VTM-extra 2023 av Rafael Holgersson.
+Policyn uppdaterades HTM1 2025 av Isak Kallini och Felix Ohrgren.
+
+# Insamling av personuppgifter
+
+## Vilken data samlar vi in?
+
+D-sektionen samlar i normalfallet in följande information från
+användare:
+
+- Namn
+
+- E-postadress
+
+- År då studierna påbörjades
+
+- Matpreferens
+
+- StiL-id från Lunds universitet
+
+I samband med särskilda evenemang eller händelser kan D-sektionen komma
+att samla in ytterligare personuppgifter eller annan information. När
+detta sker ska det anges tydligt vad för information som samlas in och
+anledningen till att uppgiften behöver samlas in och lagras.
+
+Användare på D-sektionens digitala tjänster har möjlighet att själva
+dela information som kan komma att utgöra personuppgifter, exempelvis
+profilbilder, med D-sektionens digitala tjänster. Om användaren själv
+delar information samtycker denne till att informationen sparas och
+tillgängliggörs för allmänheten.
+
+Utöver ovan nämnd data samlas teknisk information in vid besök på och
+användande av Dsektionens digitala tjänster. Detta inkluderar IP-adress
+och webbläsarinformation.
+
+## Hur samlas datan in?
+
+Majoriteten av den data D-sektionen samlar in lämnas direkt av personen
+i fråga. Vi samlar in och behandlar data när en person:
+
+- Skapar ett konto på vår hemsida.
+
+- Ändrar information i sin profil på vår hemsida
+
+- Kommunicerar med sektionen eller dess funktionärer
+
+- Besöker och nyttjar sektionens digitala tjänster
+
+- Fyller i ett formulär inför ett evenemang
+
+- I samband med betalning eller anmälan för ett evenemang
+
+Exempel på evenemang kan vara:
+
+- Sittning eller annat event
+
+- Lunchföreläsning, Casekväll eller liknande
+
+- Idrottsevenemang
+
+Vid insamling av data inför ett event skall syftet med att samla in
+personuppgifterna, vem som har tillgång till dessa samt under vilken
+tidsperiod de lagras ska tydliggöras i sektionens registerförteckning.
+Samma information skall också tydligt framgå för personen som skall
+lämna sina uppgifter.
+
+I samband med att personuppgifterna hämtas skall godkännande från
+personen i fråga också hämtas. Samtycke måste lämnas aktivt och tydligt
+samt skall sparas tills dess att uppgifterna raderas. Samtycke kan ges
+muntligt om detta dokumenteras på tillfredsställande vis. Om personen
+inte godkänner att dennes personuppgifter sparas ska sektionen ej spara
+dessa. Funktionären som samlar in uppgifterna ansvarar för att vid samma
+tillfälle också samla in och dokumentera samtycke. Det ska tydligt
+framgå vad som sparas och till vilket syfte.
+
+I vissa fall kan D-sektionen komma att hantera personuppgifter med
+ursprung i externa källor. När detta sker ska personen i fråga meddelas
+om vilka uppgifter som lagras och ursprunget till dessa. Exempel på
+detta kan vara:
+
+- Namn och kontaktuppgifter inför nollningen, där uppgifterna kommer
+  från Teknologkåren vid LTH
+
+# Hantering av personuppgifter
+
+## Hur använder vi data?
+
+D-sektionen samlar in data genom vår hemsida så att vi kan:
+
+- Hantera ditt konto
+
+- Tillhandahålla information om vem som är med i D-sektionen och vilken
+  post
+
+- Hantera åtkomst i våra system
+
+- Hantera fysisk åtkomst till D-sektionens lokaler
+
+Vid insamling av data inför ett event samlas denna data in så att
+D-sektionen kan planera och genomföra event på ett smidigt sätt med
+avseende på deltagarantal, biljetter, insläpp och matpreferenser.
+
+## Hur lagrar vi data?
+
+Data som samlas in genom vår hemsida lagras första hand säkert på
+D-sektionens servrar som finns i våra lokaler. Namn, StiL-id och
+e-postadresser lagras även i Google för att möjliggöra hantering av och
+tillgång till mailsystem och fildelning. All internettrafik på vår
+hemsida är krypterad och ett system för åtkomstkontroll finns för att
+hålla din data säker på våra servrar.
+
+Data som samlas in inför event lagras i olika tjänster, exempelvis
+sektionens Google Drive eller Orbi.
+
+Teknisk information om besök på hemsidor och digitala tjänster, som
+IP-adresser och webbläsarinformation, kan inte kopplas till en specifik
+användare och sparas frikopplat från övriga personuppgifter.
+
+## Vem kan komma att ta del av datan?
+
+Den data som visas på användarprofiler på sektionens hemsida delas
+offentligt, vilket i normalfallet omfattar namn, e-postadress, år för
+studiestart och StiL-id från Lunds universitet. Övrig data som inte är
+publik kan komma att hanteras av funktionärer som har åtkomst till
+sektionens servrar med syfte att underhålla tjänster och system samt
+kunna ta bort data vid förfrågan. Ansvarig för dessa funktionärer är
+ordförande för berört utskott.
+
+Data som samlas in inför evenemang hanteras av funktionären som är
+ansvarig för evenemanget och som samlade in uppgifterna. Ordförande för
+berört utskott är ansvarig för att funktionären hanterar uppgifterna
+enligt policyn. Personuppgifter från det tillfälliga registret kan
+endast begäras ut av personen i fråga under förutsättningen att den kan
+identifiera sig med godkänd ID-handling. I övrigt kan endast
+personuppgifter lämnas ut till andra parter på skriftligt beslut från
+Styrelsen. Styrelsen är skyldig att informera personen ifråga innan
+personuppgifterna lämnas ut.
+
+Funktionären som samlar in personuppgifterna är ansvarig för att
+uppgifterna inte sprids eller missbrukas på något sätt. Vid dataintrång
+eller annat missbruk skall personen vars uppgifter utnyttjats
+underrättas om situationen direkt. Styrelsen är ansvarig för att berörda
+parter underrättas vid dataintrång/spridning/missbruk.
+
+När godkännande för tillfällig lagring av personuppgifter samlas in ska
+också ett datum anges där personuppgifterna kommer raderas. Detta datum
+ska vara efter potentiellt evenemang eller då de inte längre kommer
+användas. Exempel kan vara efter ett val, eller i slutet av året när ens
+funktionärer har fått sitt tack. Om radering ej är möjlig ska
+uppgifterna anonymiseras. Funktionären som samlat in personuppgifterna
+är ansvarig för radering/anonymisering.
+
+# Lagring av personuppgifter
+
+Personuppgifter som tillfälligt samlas in lagras på konton kopplade till
+Sektionens Google-konton. Uppgifterna lagras tills dess att evenemanget
+är genomfört och det inte längre finns något syfte att spara dem.
+
+## Tillgänglighet
+
+Vid behov kan andra funktionärer ges tillgång till de insamlade
+personuppgifterna i ställföreträdande syfte eller som extra bemanning.
+Den ansvariga funktionären ska kunna redogör vem som har haft tillgång
+till systemet, i vilket syfte och under vilken tidsperiod.
+
+## Vilka dataskyddsrättigheter finns?
+
+Personer vars uppgifter finns lagrade hos D-sektionen har rätt till
+följande:
+
+- att begära kopior/utdrag av personuppgifter från D-sektionen
+
+- att begära att D-sektionen korrigerar information som personen i fråga
+  anser vara felaktig, samt komplettering av ofullständig information
+
+- att begära att D-sektionen raderar personuppgifter, under vissa
+  förutsättningar.
+
+- att begära att D-sektionen begränsar behandlingen av personuppgifter,
+  under vissa förutsättningar
+
+- att invända mot D-sektionens behandling av personuppgifter, under
+  vissa förutsättningar
+
+- att begära att D-sektionen överför de uppgifter vi har samlat in till
+  en annan organisation, eller direkt till personen i fråga, under vissa
+  förutsättningar
+
+Förfrågan om att verkställa ovan nämnda rättigheter ska besvaras inom en
+månad. Begäran görs genom kontakt direkt med styrelsen via e-post:
+styrelsen@dsek.se
+
+# Cookies
+
+Cookies är textfiler som placeras på användarens dator för att samla in
+standardinformation om internetloggar och besökares beteende. Vid besök
+på våra webbplatser kan vi komma att automatiskt samla in information
+från genom cookies eller liknande teknik.
+
+För mer information, besök allaboutcookies.org.
+
+## Hur använder vi cookies?
+
+D-sektionen använder cookies på olika sätt för att förbättra upplevelse
+på vår webbplats, bland annat för:
+
+- att hålla användaren inloggad
+
+- att spara information om personliga preferenser när hemsidan används,
+  exempelvis vilket språk sidan ska visas på.
+
+## Vilka typer av cookies används?
+
+Det finns flera olika typer av cookies. D-sektionens hemsida använder
+funktionella cookies, vars syfte är att tillgängliggöra funktionalitet
+på hemsidan. En blandning av förstapartscookies och tredjepartscookies
+används.
+
+## Hur hanterar användaren cookies?
+
+Användarens webbläsare kan konfigureras så att den inte accepterar
+cookies. På webbplatsen ovan finns information om hur man tar bort
+cookies från webbläsaren. Att inaktivera cookies kan i vissa fall
+medföra att viss funktionalitet på hemsidan blir otillgänglig.
+
+# Policy för insamling av persondata för andra hemsidor
+
+D-sektionens hemsida innehåller länkar till andra hemsidor. Vår policy
+för hantering av personuppgifter gäller endast för vår hemsida. Vid
+besök på andra hemsidor som länkas från Dsektionens hemsida bör
+användaren försäkra sig om den externa sidans rutiner kring hantering av
+personuppgifter före besöket.
+
+# Ansvar
+
+D-sektionen och dess företrädare (d.v.s styrelsen) är ytterst ansvarig
+för att insamling, lagring samt hantering av personuppgifter sker på
+korrekt sätt enligt lag och sektionens antagna bestämmelser. Respektive
+utskottsordförande är ansvarig för att medlemmarna inom utskottet sköter
+insamling, lagring och hantering på rätt sätt.
+
+## Kontakt gällande personuppgiftsfrågor
+
+Vid frågor om D-sektionens policy för hantering av personuppgifter, den
+data vi har samlat in om dig eller om utövandet av ovan nämnda
+dataskyddsrättigheter kan styrelsen kontaktas på följande e-postadress:
+styrelsen@dsek.se
+
+## Hur lämpliga myndigheter kontaktas
+
+Vid rapportering av klagomål gällande hantering av personuppgifter eller
+kring ärenden som relaterar till personuppgiftshantering kan
+Integritetsskyddsmyndigheten kontaktas på följande e-postadress:
+imy@imy.se
+`;
+</script>
+
+<MarkdownBody class="max-w-full" body={policy} />

--- a/src/routes/(app)/songbook/+page.server.ts
+++ b/src/routes/(app)/songbook/+page.server.ts
@@ -5,9 +5,16 @@ import {
   getPageOrThrowSvelteError,
   getPageSizeOrThrowSvelteError,
 } from "$lib/utils/url.server";
+import { error } from "@sveltejs/kit";
+import * as m from "$paraglide/messages";
 
 export const load: PageServerLoad = async ({ locals, url }) => {
   const { prisma, user } = locals;
+
+  if (!user.studentId) {
+    throw error(403, m.errors_missingPermissions());
+  }
+
   const songCount = await prisma.song.count();
   const pageSize = getPageSizeOrThrowSvelteError(url);
   const page = getPageOrThrowSvelteError(url, {

--- a/src/routes/routes.ts
+++ b/src/routes/routes.ts
@@ -138,7 +138,7 @@ export const getRoutes = (): Route[] =>
           title: m.songBook(),
           path: "/songbook",
           icon: "i-mdi-library-music",
-          accessRequired: null,
+          accessRequired: "_",
           appBehaviour: "home-link",
         },
         {


### PR DESCRIPTION
### 🧩 Summary
- Hides the image gallery during the nollning (closes #1191)
- Removes songbook access for logged-out users
- Fix access control for admin pages (closes #1190)
- Fix access policies for food preferences (partially fixes #550 and #610)
- Updates the privacy policy to the current one (slightly unrelated but might as well)