### PR TITLE
Remove data-sveltekit-reload attribute from <body>

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -14,11 +14,7 @@
     />
     %sveltekit.head%
   </head>
-  <body
-    class="flex min-h-screen flex-col"
-    data-sveltekit-preload-data="hover"
-    data-sveltekit-reload
-  >
+  <body class="flex min-h-screen flex-col" data-sveltekit-preload-data="hover">
     <div class="contents">%sveltekit.body%</div>
   </body>
 </html>


### PR DESCRIPTION
### 🧩 Summary

Remove the `data-sveltekit-reload` attribute from the `<body>` tag to enable client-side routing.

### 💬 Other information

Maybe this is intentional and needed during the migration?

