### PR TITLE
Fix daisy login error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
-FROM node:22.14.0-alpine3.21 AS base
-RUN apk --no-cache add git
-RUN apk --no-cache add openssl
+FROM node:22.14.0-slim AS base
+RUN apt update && apt install -y git
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
 RUN npm install -g pnpm@9.12.2


### PR DESCRIPTION
### 🧩 Summary

Change the base image used from `node:alpine` to `node:slim`. This image is based on a minimal version of debian instead of alpine. This makes the image 180 MB larger, (1.38 GB instead of 1.1) but should otherwise work the same if not better.

### 🔗 Related issues (if any)

Should fix the error you get when logging in to [daisy.dsek.se](https://daisy.dsek.se/)

The problem I found in the server logs is failure in name resolution of auth.dsek.se, which is most likely caused by a known difference in behavior between the DNS implementation in alpine and other major linux distros.  
_[Read more](https://stackoverflow.com/questions/65181012/does-alpine-have-known-dns-issue-within-kubernetes)_

### 📸 Screenshots / recordings (if applicable)

<img width="445" height="355" alt="image" src="https://github.com/user-attachments/assets/a6c09db4-a076-416d-9326-202fa47c1a0b" />

### 💬 Other information

This change should also be included in the `daisy` branch
