### PR TITLE
nolla: add cpu to board and fix links

### DIFF
--- a/src/routes/(nollning)/nolla/sektionen/+page.svelte
+++ b/src/routes/(nollning)/nolla/sektionen/+page.svelte
@@ -69,7 +69,7 @@
       </h3>
       <p class="nolla-prose">
         {@html m.nolla_guild_board_description()}
-        <a href="/committees" class="link">{@html m.nolla_readMore()}</a>
+        <a href="/about" class="link">{@html m.nolla_readMore()}</a>
       </p>
     </div>
 
@@ -121,6 +121,10 @@
         <b>{@html m.nolla_guild_board_activities()}</b>
         {@html m.nolla_guild_board_activities_description()}
       </li>
+      <li>
+        <b>{@html m.nolla_guild_board_cpu()}</b>
+        {@html m.nolla_guild_board_cpu_description()}
+      </li>
     </ul>
   </section>
 
@@ -138,7 +142,7 @@
 
       <a
         class="neo-brutal-btn-flat w-min whitespace-nowrap"
-        href="https://dchip.dsek.se"
+        href="https://dchip.se"
       >
         {@html m.nolla_guild_dchip_link()}
       </a>

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -744,6 +744,8 @@
   "nolla_guild_board_kallarm_description": "responsible for the guild's premises, hardware, and car.",
   "nolla_guild_board_activities": "Head of activities",
   "nolla_guild_board_activities_description": "organizes everything between sports and games.",
+  "nolla_guild_board_cpu": "Head Processor",
+  "nolla_guild_board_cpu_description": "is responsible for the guild's website, servers, and other technical operations.",
   "nolla_guild_dchip_description": "D-Chip is a non-profit, student-driven association at the D-guild to which students of Computer Science and InfoCom at LTH belong. All female and non-binary students in the two programs can join D-Chip. We exist to promote your well-being in the guild and to work for more female and non-binary engagement. On the Sunday before the nollning starts (25th of August) D-Chip will organize a free lunch for all new students at the D-guild who identify as female or non-binary, more info will be given to you by your phadder before the 19th of august!",
   "nolla_guild_dchip_link": "D-Chip's website",
   "nolla_guild_header": "The D-guild",

--- a/src/translations/sv.json
+++ b/src/translations/sv.json
@@ -742,6 +742,8 @@
   "nolla_guild_board_kallarm_description": "ansvarar för sektionens lokaler, hårdvara och bil.",
   "nolla_guild_board_activities": "Aktivitetsansvarig",
   "nolla_guild_board_activities_description": "håller i allt mellan sport och spel.",
+  "nolla_guild_board_cpu": "Processmästaren",
+  "nolla_guild_board_cpu_description": "ansvarar för sektionens hemsida, servrar och annan teknisk verksamhet.",
   "nolla_guild_dchip_description": "D-Chip är en ideell, studentdriven förening vid D-sektionen som studenterna på Datateknik och InfoCom på LTH hör till. Alla kvinnliga och icke-binära studenter på de två programmen kan vara med i D-Chip. Vi finns för att främja er trivsel på sektionen samt att verka för mer kvinnligt och icke-binärt engagemang. På söndagen innan nollningen börjar (25e augusti) kommer D-chip att anordna en gratis lunch för alla nyantagna studenter på D-sektionen som identifierar sig som kvinna eller icke-binär, mer info kommer du få av dina phaddrar innan den 19e augusti!",
   "nolla_guild_dchip_link": "D-Chips hemsida",
   "nolla_guild_header": "D-sektionen",


### PR DESCRIPTION
### 🧩 Summary
add cpu to board members, fix links to /about and dchip.se

### 📸 Screenshots / recordings (if applicable)
<img width="1276" height="482" alt="image" src="https://github.com/user-attachments/assets/fa2edb9d-5582-4d5b-b86a-8d723274b69d" />
