### PR TITLE
fix broken link in nolla_packing_money_description

### DIFF
--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -710,7 +710,7 @@
   "nolla_packing_needle": "Needle and thread",
   "nolla_packing_needle_description": "Your lovely ouvve is not supposed to be worn blank, it should be decorated with a bunch of patches! You will receive a lot of patches during the nollning, and to put this on your ouvve it's nice to have a simple sewing kit close to hand. You can of course use textile glue, it's a popular choice by some lazier students, but it's not as robust.",
   "nolla_packing_money": "Money",
-  "nolla_packing_money_description": "In the start of the school year there are quite a few expenses. Course literature, first rent, furniture, Ouvve, event during the nollning to name a few. If you are eligible for CSN, even it will not arrive in your account until after a few weeks, so keeping extra money on hand at the start is recommended!",
+  "nolla_packing_money_description": "In the start of the school year there are quite a few expenses. Course literature, first rent, furniture, Ouvve, event during the nollning to name a few. If you are eligible for <a href=\"wordlist#csn\" class=\"link\">CSN</a>,  even it will not arrive in your account until after a few weeks, so keeping extra money on hand at the start is recommended!",
   "nolla_packing_bike": "Bike",
   "nolla_packing_bike_description": "A bike is the Lund student's best friend. The whole town is made to be biked around and you rarely travel any distance longer than 15 minutes on a bike. In the start of the school year the pressure is high on bikes so if you are able to bring your own it will be more convenient.",
   "nolla_ouvve_titel": "Ouvve",

--- a/src/translations/sv.json
+++ b/src/translations/sv.json
@@ -707,7 +707,7 @@
   "nolla_packing_needle": "Nål och tråd",
   "nolla_packing_needle_description": "Din kära <a href=\"wordlist#ouvve\" class=\"link\">ouvve</a> ska ju inte bäras blank, utan det ska smyckras med en massa märken. Många sådana kommer du få tag på under nollningen. För att fästa märken kan det vara bra att ha en nål och tråd till hands. Det går även bra att använda textillim, populärt val bland vissa latare studenter, men det håller inte lika bra.",
   "nolla_packing_money": "Pengar",
-  "nolla_packing_money_description": "I början av skolåret kommer en hel del kostnader. Köpa kurslitteratur, första hyran, inredning, Ouvve, nollningsevent för att nämna de stora. <a href=\"ordlista#csn\" class=\"link\">CSN</a> kommer inte förrän efter några veckor så det kan vara bra att ha det i åtanke.",
+  "nolla_packing_money_description": "I början av skolåret kommer en hel del kostnader. Köpa kurslitteratur, första hyran, inredning, Ouvve, nollningsevent för att nämna de stora. <a href=\"wordlist#csn\" class=\"link\">CSN</a> kommer inte förrän efter några veckor så det kan vara bra att ha det i åtanke.",
   "nolla_packing_bike": "Cykel",
   "nolla_packing_bike_description": "Cykeln är lundastudentens bästa vän. Hela staden är anpassad för att cyklas i och det är sällan mer än 15 minuter att cykla. I början på året är trycket högt på cyklar så det rekommenderas att ta med, eller köpa innan rushen.",
   "nolla_ouvve_titel": "Ouvve",


### PR DESCRIPTION
### 🧩 Summary

Fixes a broken link in nolla.nu in the packinglist,

### 💬 Other information

Also adds a link to the English translation