### PR TITLE
Fix iOS notification badge not clearing

### DIFF
--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -3,6 +3,8 @@
   import Alert from "$lib/components/Alert.svelte";
   import Header from "./Header.svelte";
   import Footer from "./Footer.svelte";
+  import AppNotificationTokenHandler from "$lib/components/utils/AppNotificationTokenHandler.svelte";
+  import AppUnreadNotificationHandler from "$lib/components/utils/AppUnreadNotificationHandler.svelte";
   import { getLocale } from "$paraglide/runtime";
   import { page } from "$app/state";
 
@@ -19,6 +21,15 @@
     : 0) + "px"}
 >
   <Header notificationsPromise={data.notificationsPromise} isApp={data.isApp} />
+
+  {#if data.isApp}
+    {#await data.notificationsPromise then notifications}
+      <AppUnreadNotificationHandler
+        notificationCount={notifications?.filter((n) => !n.readAt).length}
+      />
+    {/await}
+    <AppNotificationTokenHandler />
+  {/if}
 
   <main class="flex min-h-0 flex-1 flex-col">
     {#each data.alerts as alert (alert.id)}


### PR DESCRIPTION
## Summary
- `AppUnreadNotificationHandler` and `AppNotificationTokenHandler` were dropped from `(app)/+layout.svelte` when the old design was removed in 5b797ca9, silently severing the bridge that tells the native wrapper app the unread notification count (used to set/clear the iOS badge) and that uploads push tokens.
- Android masked this because its shade badge clears on notification dismissal independent of app code; iOS's badge is a persistent counter that only updates via the now-unreachable `setBadgeCountAsync` call.
- Re-mounts both handlers, gated on `data.isApp`, matching how the old layout wired them up.

## Test plan
- [x] `pnpm check` passes with no errors
- [x] `eslint` passes on the changed file
- [ ] Manual verification on an iOS device that opening notifications clears the app badge