### PR TITLE
fix document links not updating with year filter

### DIFF
--- a/src/routes/(app)/documents/Meeting.svelte
+++ b/src/routes/(app)/documents/Meeting.svelte
@@ -34,9 +34,11 @@
       )
       .pop();
 
-  let notice = findFile(["Kallelse", "Notice"]);
-  let agenda = findFile(["Föredragningslista", "Foredragningslista", "Agenda"]);
-  let minutes = findFile(["Protokoll", "Minutes, Minute"]);
+  let notice = $derived(findFile(["Kallelse", "Notice"]));
+  let agenda = $derived(
+    findFile(["Föredragningslista", "Foredragningslista", "Agenda"]),
+  );
+  let minutes = $derived(findFile(["Protokoll", "Minutes, Minute"]));
 
   let filteredFiles = $derived(
     files.filter((f) => {


### PR DESCRIPTION
Closes #1295 

Added `$derived` to the variables so they update whenever the filters change.