### PR TITLE
Lazy load notification bell and use a cheap unread count

### DIFF
--- a/src/lib/utils/notifications/myNotifications.ts
+++ b/src/lib/utils/notifications/myNotifications.ts
@@ -63,3 +63,81 @@ export const getMyGroupedNotifications = async (
   const myNotifications = await getMyNotifications(user, prisma);
   return groupNotifications(myNotifications);
 };
+
+export const NOTIFICATIONS_PAGE_SIZE = 20;
+
+const getMyNotificationsPage = (
+  user: AuthUser,
+  prisma: ExtendedPrisma,
+  take: number,
+): Promise<ExpandedNotification[]> => {
+  return prisma.notification.findMany({
+    where: {
+      memberId: user.memberId,
+    },
+    orderBy: {
+      id: "desc",
+    },
+    // fetch one extra row to know whether there are more pages left
+    take: take + 1,
+    include: {
+      fromAuthor: {
+        select: {
+          id: true,
+          type: true,
+          member: {
+            select: {
+              firstName: true,
+              nickname: true,
+              lastName: true,
+              picturePath: true,
+            },
+          },
+          mandate: {
+            select: {
+              position: {
+                select: {
+                  name: true,
+                },
+              },
+            },
+          },
+          customAuthor: {
+            select: {
+              name: true,
+              imageUrl: true,
+            },
+          },
+        },
+      },
+    },
+  });
+};
+
+export const getMyGroupedNotificationsPage = async (
+  user: AuthUser,
+  prisma: ExtendedPrisma,
+  take: number = NOTIFICATIONS_PAGE_SIZE,
+) => {
+  const notifications = await getMyNotificationsPage(user, prisma, take);
+  const hasMore = notifications.length > take;
+
+  return {
+    notifications: groupNotifications(
+      hasMore ? notifications.slice(0, take) : notifications,
+    ),
+    hasMore,
+  };
+};
+
+export const getUnreadNotificationCount = (
+  user: AuthUser,
+  prisma: ExtendedPrisma,
+): Promise<number> => {
+  return prisma.notification.count({
+    where: {
+      memberId: user.memberId,
+      readAt: null,
+    },
+  });
+};

--- a/src/routes/(app)/+layout.server.ts
+++ b/src/routes/(app)/+layout.server.ts
@@ -1,6 +1,6 @@
 import { env } from "$env/dynamic/public";
 import { countUserShopItems } from "$lib/server/shop/countUserShopItems";
-import { getMyGroupedNotifications } from "$lib/utils/notifications/myNotifications";
+import { getUnreadNotificationCount } from "$lib/utils/notifications/myNotifications";
 import { emptySchema, notificationSchema } from "$lib/zod/schemas";
 import { loadFlash } from "sveltekit-flash-message/server";
 import { zod4 } from "sveltekit-superforms/adapters";
@@ -17,13 +17,12 @@ const alertsCache: {
 };
 
 export const load = loadFlash(async ({ locals, depends }) => {
-  depends("/api/notifications/my");
   depends("cart");
   depends("alerts");
 
-  const { user, prisma } = locals;
-  const notificationsPromise = user?.memberId
-    ? getMyGroupedNotifications(user, prisma)
+  const { prisma, user } = locals;
+  const unreadCountPromise = user?.memberId
+    ? getUnreadNotificationCount(user, prisma)
     : undefined;
   const shopItemCounts = countUserShopItems(prisma, user);
 
@@ -39,7 +38,7 @@ export const load = loadFlash(async ({ locals, depends }) => {
 
   return {
     alerts: alertsCache.alerts,
-    notificationsPromise,
+    unreadCountPromise,
     mutateNotificationForm: await superValidate(zod4(notificationSchema)),
     readNotificationForm: await superValidate(zod4(emptySchema)),
     shopItemCounts,

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -18,7 +18,7 @@
     ? (page.data.appInfo?.insets?.bottom ?? 0) + 64
     : 0) + "px"}
 >
-  <Header notificationsPromise={data.notificationsPromise} isApp={data.isApp} />
+  <Header unreadCountPromise={data.unreadCountPromise} isApp={data.isApp} />
 
   <main class="flex min-h-0 flex-1 flex-col">
     {#each data.alerts as alert (alert.id)}

--- a/src/routes/(app)/Header.svelte
+++ b/src/routes/(app)/Header.svelte
@@ -29,7 +29,6 @@
 
   import * as HoverCard from "$lib/components/ui/hover-card";
   import { cn } from "$lib/utils";
-  import type { NotificationGroup } from "$lib/utils/notifications/group";
   import MemberAvatar from "$lib/components/member/MemberAvatar.svelte";
   import NotificationBell from "./notifications/NotificationBell.svelte";
   import { CircleUserRound, UserRoundPlus } from "@lucide/svelte";
@@ -37,10 +36,9 @@
   import { getFileUrl } from "$lib/files/client";
 
   const {
-    notificationsPromise,
+    unreadCountPromise,
     isApp,
-  }: { notificationsPromise?: Promise<NotificationGroup[]>; isApp: boolean } =
-    $props();
+  }: { unreadCountPromise?: Promise<number>; isApp: boolean } = $props();
 
   const canAccess = (accessRequired: string | null) =>
     accessRequired === null || isAuthorized(accessRequired, page.data.user);
@@ -139,7 +137,7 @@
         class="p-1.5"><Languages /></Button
       >
       {#if page.data.member}
-        <NotificationBell {notificationsPromise} />
+        <NotificationBell {unreadCountPromise} />
         <HoverCard.Root bind:open={memberOpen} openDelay={0} closeDelay={125}>
           <HoverCard.Trigger onclick={() => (memberOpen = !memberOpen)}>
             <MemberAvatar

--- a/src/routes/(app)/app/home/+page.svelte
+++ b/src/routes/(app)/app/home/+page.svelte
@@ -34,13 +34,10 @@
             <h1 class="font-sans whitespace-nowrap">
               {m.home_greeting({ name: data.member?.firstName ?? "" })}
             </h1>
-            {#await data.notificationsPromise}
+            {#await data.unreadCountPromise}
               {m.home_notificationCount({ count: 0 })}
-            {:then notifications}
-              {m.home_notificationCount({
-                count:
-                  notifications?.filter((n) => n.readAt === null).length ?? 0,
-              })}
+            {:then count}
+              {m.home_notificationCount({ count: count ?? 0 })}
             {/await}
           </div>
         </div>{:else}

--- a/src/routes/(app)/home/+page.svelte
+++ b/src/routes/(app)/home/+page.svelte
@@ -25,13 +25,10 @@
           <h1 class="font-sans whitespace-nowrap">
             {m.home_greeting({ name: data.member?.firstName ?? "" })}
           </h1>
-          {#await data.notificationsPromise}
+          {#await data.unreadCountPromise}
             {m.home_notificationCount({ count: 0 })}
-          {:then notifications}
-            {m.home_notificationCount({
-              count:
-                notifications?.filter((n) => n.readAt === null).length ?? 0,
-            })}
+          {:then count}
+            {m.home_notificationCount({ count: count ?? 0 })}
           {/await}
         </div>
       </div>

--- a/src/routes/(app)/notifications/NotificationBell.svelte
+++ b/src/routes/(app)/notifications/NotificationBell.svelte
@@ -3,34 +3,66 @@
   import * as HoverCard from "$lib/components/ui/hover-card";
   import Bell from "@lucide/svelte/icons/bell";
   import type { NotificationGroup } from "$lib/utils/notifications/group";
-  import { readAllNotifications } from "./data.remote";
+  import { getNotifications, readAllNotifications } from "./data.remote";
   import NotificationList from "./NotificationList.svelte";
   import { enhanceWithToast } from "$lib/stores/toast";
 
-  const {
-    notificationsPromise,
-  }: { notificationsPromise?: Promise<NotificationGroup[]> } = $props();
+  const PAGE_SIZE = 20;
+
+  const { unreadCountPromise }: { unreadCountPromise?: Promise<number> } =
+    $props();
 
   let open = $state(false);
 
-  // Locally mark notifications as read to optimistically hide the badge
-  let locallyMarkedRead = $state(false);
-  let resolvedNotifications: NotificationGroup[] = $state([]);
-  let unreadCount = $derived(
-    locallyMarkedRead
-      ? 0
-      : resolvedNotifications.filter((n) => n.readAt === null).length,
-  );
-
+  let serverUnreadCount = $state(0);
   $effect(() => {
-    if (!notificationsPromise) {
-      resolvedNotifications = [];
+    if (!unreadCountPromise) {
+      serverUnreadCount = 0;
       return;
     }
-    notificationsPromise.then((list) => {
-      resolvedNotifications = list ?? [];
+    unreadCountPromise.then((count) => {
+      serverUnreadCount = count ?? 0;
     });
   });
+
+  // Locally mark notifications as read to optimistically hide the badge
+  let locallyMarkedRead = $state(false);
+  let unreadCount = $derived(locallyMarkedRead ? 0 : serverUnreadCount);
+
+  let notifications: NotificationGroup[] = $state([]);
+  let hasMore = $state(false);
+  let listLoaded = $state(false);
+  let initialLoading = $state(false);
+  let loadingMore = $state(false);
+  let take = PAGE_SIZE;
+
+  async function loadNotifications(newTake: number) {
+    if (newTake === PAGE_SIZE) initialLoading = true;
+    else loadingMore = true;
+    try {
+      const result = await getNotifications({ take: newTake });
+      notifications = result.notifications;
+      hasMore = result.hasMore;
+      take = newTake;
+      listLoaded = true;
+    } finally {
+      initialLoading = false;
+      loadingMore = false;
+    }
+  }
+
+  function loadMore() {
+    void loadNotifications(take + PAGE_SIZE);
+  }
+
+  function handleDismissed(id: number) {
+    notifications = notifications.filter((n) => n.id !== id);
+  }
+
+  function handleClearedAll() {
+    notifications = [];
+    hasMore = false;
+  }
 
   let readForm: HTMLFormElement | null = $state(null);
 
@@ -42,7 +74,9 @@
   }
 
   $effect(() => {
-    if (open) markAllAsRead();
+    if (!open) return;
+    markAllAsRead();
+    if (!listLoaded) void loadNotifications(take);
   });
 </script>
 
@@ -79,6 +113,15 @@
     class="z-150 flex w-[min(450px,calc(100vw-2rem))] flex-col p-0"
     align="end"
   >
-    <NotificationList {notificationsPromise} listClass="max-h-[60vh]" />
+    <NotificationList
+      {notifications}
+      {initialLoading}
+      {loadingMore}
+      {hasMore}
+      listClass="max-h-[60vh]"
+      onLoadMore={loadMore}
+      onDismissed={handleDismissed}
+      onClearedAll={handleClearedAll}
+    />
   </HoverCard.Content>
 </HoverCard.Root>

--- a/src/routes/(app)/notifications/NotificationItem.svelte
+++ b/src/routes/(app)/notifications/NotificationItem.svelte
@@ -7,7 +7,11 @@
   import { deleteNotification } from "./data.remote";
   import { enhanceWithToast } from "$lib/stores/toast";
 
-  const { notification }: { notification: NotificationGroup } = $props();
+  const {
+    notification,
+    onDismissed,
+  }: { notification: NotificationGroup; onDismissed?: (id: number) => void } =
+    $props();
 </script>
 
 <div
@@ -29,7 +33,14 @@
       </span>
     </div>
   </a>
-  <form {...enhanceWithToast(deleteNotification.for(notification.id))}>
+  <form
+    {...enhanceWithToast(
+      deleteNotification.for(notification.id),
+      async (helpers) => {
+        if (await helpers.submit()) onDismissed?.(notification.id);
+      },
+    )}
+  >
     {#if notification.individualIds.length > 1}
       <input
         type="hidden"

--- a/src/routes/(app)/notifications/NotificationList.svelte
+++ b/src/routes/(app)/notifications/NotificationList.svelte
@@ -9,39 +9,68 @@
   import { enhanceWithToast } from "$lib/stores/toast";
 
   const {
-    notificationsPromise,
+    notifications,
+    initialLoading = false,
+    loadingMore = false,
+    hasMore = false,
     listClass = "max-h-[60vh]",
+    onLoadMore,
+    onDismissed,
+    onClearedAll,
   }: {
-    notificationsPromise?: Promise<NotificationGroup[]>;
+    notifications: NotificationGroup[];
+    initialLoading?: boolean;
+    loadingMore?: boolean;
+    hasMore?: boolean;
     listClass?: string;
+    onLoadMore?: () => void;
+    onDismissed?: (id: number) => void;
+    onClearedAll?: () => void;
   } = $props();
 </script>
 
-{#await notificationsPromise}
+{#if initialLoading}
   <div class="p-4"><Spinner /></div>
-{:then notifications}
-  {@const list = notifications ?? []}
+{:else}
   <div class="flex flex-col gap-2 overflow-y-auto p-2 {listClass}">
-    {#each list as notification (notification.id)}
-      <NotificationItem {notification} />
+    {#each notifications as notification (notification.id)}
+      <NotificationItem {notification} {onDismissed} />
     {/each}
-    {#if list.length === 0}
+    {#if notifications.length === 0}
       <p class="text-muted-foreground py-4 text-center text-sm">
         {m.navbar_bell_noNotifications()}
       </p>
+    {:else if hasMore}
+      <Button
+        aria-label={m.navbar_bell_loadMore()}
+        variant="ghost"
+        class="text-muted-foreground w-full"
+        disabled={loadingMore}
+        onclick={onLoadMore}
+      >
+        {#if loadingMore}
+          <Spinner class="size-4" />
+        {:else}
+          {m.navbar_bell_loadMore()}
+        {/if}
+      </Button>
     {/if}
   </div>
   <div class="border-t p-2">
-    <form {...enhanceWithToast(deleteAllNotifications)}>
+    <form
+      {...enhanceWithToast(deleteAllNotifications, async (helpers) => {
+        if (await helpers.submit()) onClearedAll?.();
+      })}
+    >
       <Button
         aria-label={m.navbar_bell_deleteAll()}
         variant="ghost"
         class="text-muted-foreground w-full"
         type="submit"
-        disabled={list.length === 0}
+        disabled={notifications.length === 0}
         ><Trash class="size-4" />
         {m.navbar_bell_deleteAll()}</Button
       >
     </form>
   </div>
-{/await}
+{/if}

--- a/src/routes/(app)/notifications/data.remote.ts
+++ b/src/routes/(app)/notifications/data.remote.ts
@@ -1,6 +1,18 @@
-import { form, getRequestEvent } from "$app/server";
+import { form, getRequestEvent, query } from "$app/server";
 import { m } from "$paraglide/messages";
 import z from "zod";
+import { getMyGroupedNotificationsPage } from "$lib/utils/notifications/myNotifications";
+
+export const getNotifications = query(
+  z.object({ take: z.number().int().positive() }),
+  async ({ take }) => {
+    const { user, prisma } = getRequestEvent().locals;
+
+    if (!user?.memberId) return { notifications: [], hasMore: false };
+
+    return getMyGroupedNotificationsPage(user, prisma, take);
+  },
+);
 
 export const readAllNotifications = form(z.object({}), async () => {
   const { user, prisma } = getRequestEvent().locals;

--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -11,7 +11,7 @@
   const { data } = $props();
 </script>
 
-<Navbar notificationsPromise={data.notificationsPromise} isApp={data.isApp} />
+<Navbar unreadCountPromise={data.unreadCountPromise} isApp={data.isApp} />
 <main class="layout-container inline-flex flex-col gap-4 text-center">
   <div>
     <h1>{page.status}</h1>

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -368,6 +368,7 @@
   "navbar_bell_markAllAsRead": "Mark all as read",
   "navbar_bell_deleteAll": "Delete all",
   "navbar_bell_noNotifications": "You have no notifications!",
+  "navbar_bell_loadMore": "Load more",
   "navbar_userMenu_loggedInAs": "Logged in as",
   "navbar_userMenu_profile": "Profile",
   "navbar_userMenu_settings": "Settings",

--- a/src/translations/sv.json
+++ b/src/translations/sv.json
@@ -368,6 +368,7 @@
   "navbar_bell_markAllAsRead": "Markera alla som lästa",
   "navbar_bell_deleteAll": "Ta bort alla",
   "navbar_bell_noNotifications": "Du har inga notiser!",
+  "navbar_bell_loadMore": "Ladda fler",
   "navbar_userMenu_loggedInAs": "Inloggad som",
   "navbar_userMenu_profile": "Profil",
   "navbar_userMenu_settings": "Inställningar",


### PR DESCRIPTION
### 🧩 Summary

The bell fetched a user's entire notification history (with joins) on every page load just to render the unread badge, which got slow as history grew into the hundreds. The badge now comes from a cheap COUNT query streamed from the layout load (never blocking page render), and the dropdown list is fetched lazily only once opened, paginated 20 at a time via a "load more" button instead of loading everything upfront.

### 🔗 Related issues (if any)

Closes #1296
